### PR TITLE
fix(ci): disable husky hooks in update-versions workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Commit and push changes
         if: steps.check-changes.outputs.changed == 'true'
+        env:
+          HUSKY: 0  # Disable husky hooks for automated commits
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
Fixes the update-versions workflow failing due to Husky pre-commit hooks running during automated commits.

## Problem
The workflow was failing when committing updated version files:
```
husky - pre-commit script failed (code 3)
```

## Solution
Added `HUSKY: 0` environment variable to disable hooks for automated commits:

```yaml
env:
  HUSKY: 0  # Disable husky hooks for automated commits
```

This follows the same pattern used in other automated workflows.