### PR TITLE
fix(ci): remove extra quote in export-testing workflow token parameter

### DIFF
--- a/.github/workflows/export-testing.yml
+++ b/.github/workflows/export-testing.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Prepare pre-requisites
         uses: ./.github/actions/prepare
         with:
-          token: ${{ steps.gh-app-token.outputs.token }}'
+          token: ${{ steps.gh-app-token.outputs.token }}
 
       - name: Configure npm authentication for npm registry
         run: |


### PR DESCRIPTION
Fixes the export-testing workflow failing due to a syntax error in the token parameter.

## Problem
The workflow was failing with git authentication errors:
```
Error: fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

## Root Cause
Line 40 had an extra single quote breaking the token parameter:
```yaml
token: ${{ steps.gh-app-token.outputs.token }}'
```

## Solution
Removed the extra quote:
```yaml
token: ${{ steps.gh-app-token.outputs.token }}
```

This syntax error was preventing proper GitHub authentication, causing the workflow to fail.