### PR TITLE
fix(ci): checkout proper branch before committing in update-versions workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -63,6 +63,9 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          # Checkout the proper branch (handle both PR and push events)
+          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+          git checkout "$BRANCH_NAME"
           git add packages/builder/src/export/versions.ts
           git commit -m "chore: update export versions"
-          git push
+          git push origin "$BRANCH_NAME"


### PR DESCRIPTION
Fixes the update-versions workflow that was failing due to detached HEAD state when trying to push changes.\n\n## Problem\nThe workflow was failing with:\n```\nfatal: You are not currently on a branch.\nTo push the history leading to the current (detached HEAD)\nstate now, use\n    git push origin HEAD:<name-of-remote-branch>\n```\n\n## Solution\nAdded branch checkout logic that handles both PR and push events:\n\n```yaml\nBRANCH_NAME="${{ github.head_ref || github.ref_name }}"\ngit checkout "$BRANCH_NAME"\n```\n\nThis ensures the workflow operates on the proper branch instead of a detached HEAD state.