### PR TITLE
fix(ci): restore signed commits using changesets API with husky file fix

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -56,19 +56,14 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Temporarily make Husky files non-executable for API compatibility
+      - name: Commit changes
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          chmod -x .husky/* 2>/dev/null || true
-
-      - name: Create signed commit using changesets action
-        if: steps.check-changes.outputs.changed == 'true'
-        id: changesets
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
-        with:
-          commit: 'chore: update export versions'
-          title: 'chore: update export versions'
-          setupGitUser: true
-          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ steps.gh-app-token.outputs.token }}
+          HUSKY: 0  # Disable husky hooks for automated commits
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add packages/builder/src/export/versions.ts
+          git commit -m "chore: update export versions"
+          git push

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -56,16 +56,19 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push changes
+      - name: Temporarily make Husky files non-executable for API compatibility
         if: steps.check-changes.outputs.changed == 'true'
-        env:
-          HUSKY: 0  # Disable husky hooks for automated commits
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          # Checkout the proper branch (handle both PR and push events)
-          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-          git checkout "$BRANCH_NAME"
-          git add packages/builder/src/export/versions.ts
-          git commit -m "chore: update export versions"
-          git push origin "$BRANCH_NAME"
+          chmod -x .husky/* 2>/dev/null || true
+
+      - name: Create signed commit using changesets action
+        if: steps.check-changes.outputs.changed == 'true'
+        id: changesets
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+        with:
+          commit: 'chore: update export versions'
+          title: 'chore: update export versions'
+          setupGitUser: true
+          createGithubReleases: false
+        env:
+          GITHUB_TOKEN: ${{ steps.gh-app-token.outputs.token }}


### PR DESCRIPTION
Restores signed commits in the update-versions workflow by using changesets action with GitHub API while fixing the executable files issue. The previous fix removed GitHub API usage, resulting in unsigned commits. This solution uses changesets action for signed commits while temporarily removing executable permissions from Husky files for API compatibility.