### PR TITLE
fix: legacy OZ proxy resolution and admin display; adapter-driven auto-query filter; reset uses proxy ABI

### DIFF
--- a/.changeset/eighty-parents-stand.md
+++ b/.changeset/eighty-parents-stand.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-ui-builder-adapter-evm': minor
+---
+
+Resolve legacy OpenZeppelin proxy implementation/admin via storage slots; expose adminAddress in proxy info; delegate auto-query filtering to adapter to avoid admin-only getters; add storage-slot debug logs.

--- a/.changeset/red-turkeys-repair.md
+++ b/.changeset/red-turkeys-repair.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-ui-builder-types': minor
+---
+
+Extend ProxyInfo with optional adminAddress; add optional adapter method filterAutoQueryableFunctions for chain-specific auto-query filtering.

--- a/.changeset/solid-hotels-juggle.md
+++ b/.changeset/solid-hotels-juggle.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-ui-builder-renderer': minor
+---
+
+Use adapter-provided filtering for safe auto-queries to prevent calling admin-only getters; improve FunctionResult header layout to avoid overflow.

--- a/.changeset/wet-nights-write.md
+++ b/.changeset/wet-nights-write.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-ui-builder-app': minor
+---
+
+Show proxy implementation/admin in banner with explorer links and chain-agnostic copy; “Reset detection” now uses proxy ABI only (no implementation fetch); prevent reload loop on fatal load errors.

--- a/.eslint/rules/no-extra-adapter-methods.cjs
+++ b/.eslint/rules/no-extra-adapter-methods.cjs
@@ -49,6 +49,7 @@ module.exports = {
       'getSupportedExecutionMethods',
       'validateExecutionConfig',
       'isViewFunction',
+      'filterAutoQueryableFunctions',
       'queryViewFunction',
       'formatFunctionResult',
       'supportsWalletConnection',

--- a/packages/adapter-evm/src/abi/loader.ts
+++ b/packages/adapter-evm/src/abi/loader.ts
@@ -9,7 +9,7 @@ import type {
 } from '@openzeppelin/contracts-ui-builder-types';
 import { logger, simpleHash } from '@openzeppelin/contracts-ui-builder-utils';
 
-import { detectProxyFromAbi, getImplementationAddress } from '../proxy/detection';
+import { detectProxyFromAbi, getAdminAddress, getImplementationAddress } from '../proxy/detection';
 import type { AbiItem, TypedEvmNetworkConfig } from '../types';
 import { loadAbiFromEtherscan } from './etherscan';
 import { transformAbiToSchema } from './transformer';
@@ -204,6 +204,9 @@ async function handleProxyDetection(
     proxyType
   );
 
+  // Attempt to resolve admin address as well for display purposes
+  const adminAddress = await getAdminAddress(contractAddress, networkConfig);
+
   if (!implementationAddress) {
     logger.info('handleProxyDetection', 'Proxy detected but implementation address not found');
 
@@ -226,12 +229,13 @@ async function handleProxyDetection(
     proxyType
   );
 
-  const baseProxyInfo: ProxyInfo = {
+  const baseProxyInfo = {
     isProxy: true,
     proxyType,
     implementationAddress,
     proxyAddress: contractAddress,
     detectionMethod: 'automatic',
+    ...(adminAddress ? { adminAddress } : {}),
   };
 
   if (implementationResult) {

--- a/packages/adapter-evm/src/adapter.ts
+++ b/packages/adapter-evm/src/adapter.ts
@@ -309,6 +309,24 @@ export class EvmAdapter implements ContractAdapter {
   /**
    * @inheritdoc
    */
+  public filterAutoQueryableFunctions(functions: ContractFunction[]): ContractFunction[] {
+    // Exclude admin/upgrade management getters that often revert or require permissions
+    const skipNames = new Set([
+      'admin',
+      'implementation',
+      'getImplementation',
+      '_implementation',
+      'proxyAdmin',
+      'changeAdmin',
+      'upgradeTo',
+      'upgradeToAndCall',
+    ]);
+    return functions.filter((f) => !skipNames.has(f.name));
+  }
+
+  /**
+   * @inheritdoc
+   */
   async queryViewFunction(
     contractAddress: string,
     functionId: string,

--- a/packages/builder/src/components/ContractsUIBuilder/StepContractDefinition/StepContractDefinition.tsx
+++ b/packages/builder/src/components/ContractsUIBuilder/StepContractDefinition/StepContractDefinition.tsx
@@ -90,7 +90,7 @@ export function StepContractDefinition({
     // Trigger reload with proxy detection disabled
     const currentFormValues = contractState.formValues;
     if (currentFormValues && adapter) {
-      void loadContract(currentFormValues);
+      void loadContract(currentFormValues, { skipProxyDetection: true });
     }
   }, [contractState.formValues, adapter, loadContract]);
 

--- a/packages/builder/src/components/ContractsUIBuilder/StepContractDefinition/components/ContractSuccessStatus.tsx
+++ b/packages/builder/src/components/ContractsUIBuilder/StepContractDefinition/components/ContractSuccessStatus.tsx
@@ -118,6 +118,14 @@ export function ContractSuccessStatus({
     [proxyInfo?.implementationAddress, adapter]
   );
 
+  const adminExplorerUrl = useMemo(
+    () =>
+      proxyInfo?.adminAddress
+        ? adapter?.getExplorerUrl(proxyInfo.adminAddress) || undefined
+        : undefined,
+    [proxyInfo?.adminAddress, adapter]
+  );
+
   return (
     <div className="space-y-3">
       {/* Contract Definition Source Indicator */}
@@ -158,6 +166,7 @@ export function ContractSuccessStatus({
           proxyInfo={proxyInfo}
           proxyExplorerUrl={proxyExplorerUrl}
           implementationExplorerUrl={implementationExplorerUrl}
+          adminExplorerUrl={adminExplorerUrl}
           onIgnoreProxy={onIgnoreProxy}
         />
       )}

--- a/packages/builder/src/components/ContractsUIBuilder/StepContractDefinition/hooks/useContractLoader.ts
+++ b/packages/builder/src/components/ContractsUIBuilder/StepContractDefinition/hooks/useContractLoader.ts
@@ -75,7 +75,10 @@ export function useContractLoader({ adapter, ignoreProxy }: UseContractLoaderPro
    * @param data - Form values containing contract address and optional manual definition
    */
   const loadContract = useCallback(
-    async (data: FormValues) => {
+    async (
+      data: FormValues,
+      options?: { skipProxyDetection?: boolean; treatAsImplementation?: boolean }
+    ) => {
       if (!adapter || loadingRef.current) return;
       // Narrow contractAddress to string before validation
       const address =
@@ -115,7 +118,14 @@ export function useContractLoader({ adapter, ignoreProxy }: UseContractLoaderPro
         const enhancedData = {
           ...data,
           __proxyDetectionOptions: {
-            skipProxyDetection: ignoreProxyRef.current,
+            skipProxyDetection:
+              options && typeof options.skipProxyDetection === 'boolean'
+                ? options.skipProxyDetection
+                : ignoreProxyRef.current,
+            treatAsImplementation:
+              options && typeof options.treatAsImplementation === 'boolean'
+                ? options.treatAsImplementation
+                : false,
           },
         };
 
@@ -189,7 +199,7 @@ export function useContractLoader({ adapter, ignoreProxy }: UseContractLoaderPro
     circuitBreakerActive, // Whether circuit breaker is preventing loads
 
     // Actions
-    loadContract, // Main function to load a contract definition
+    loadContract, // Main function to load a contract definition (supports proxy detection options)
     canAttemptLoad, // Check if load should be attempted
     markAttempted, // Mark form values as attempted
 

--- a/packages/builder/src/components/ContractsUIBuilder/hooks/useUIBuilderState.ts
+++ b/packages/builder/src/components/ContractsUIBuilder/hooks/useUIBuilderState.ts
@@ -62,6 +62,10 @@ export function useUIBuilderState() {
         original: originalDefinition ?? '',
       });
     },
+    onError: (err) => {
+      // Record error and stop auto-retry loop
+      uiBuilderStore.setContractDefinitionError(err.message);
+    },
   });
 
   const load = useCallback(

--- a/packages/builder/src/components/warnings/ProxyStatusIndicator.tsx
+++ b/packages/builder/src/components/warnings/ProxyStatusIndicator.tsx
@@ -12,6 +12,8 @@ export interface ProxyStatusIndicatorProps {
   proxyExplorerUrl?: string;
   /** Pre-generated explorer URL for the implementation address (optional) */
   implementationExplorerUrl?: string;
+  /** Pre-generated explorer URL for the admin address (optional) */
+  adminExplorerUrl?: string;
   /** Callback when user wants to reload without proxy detection */
   onIgnoreProxy?: () => void;
   /** Optional CSS class name */
@@ -26,6 +28,7 @@ export const ProxyStatusIndicator: React.FC<ProxyStatusIndicatorProps> = ({
   proxyInfo,
   proxyExplorerUrl,
   implementationExplorerUrl,
+  adminExplorerUrl,
   onIgnoreProxy,
   className,
 }) => {
@@ -34,6 +37,7 @@ export const ProxyStatusIndicator: React.FC<ProxyStatusIndicatorProps> = ({
   }
 
   const hasImplementation = !!proxyInfo.implementationAddress;
+  const hasAdmin = !!proxyInfo.adminAddress;
 
   return (
     <div
@@ -80,6 +84,23 @@ export const ProxyStatusIndicator: React.FC<ProxyStatusIndicatorProps> = ({
               className="bg-blue-100 text-blue-800"
             />
           </div>
+
+          {hasAdmin && (
+            <div className="flex items-center gap-2 text-blue-700">
+              <span>Admin:</span>
+              <AddressDisplay
+                address={proxyInfo.adminAddress!}
+                showCopyButton={true}
+                explorerUrl={adminExplorerUrl}
+                className="bg-blue-100 text-blue-800"
+              />
+            </div>
+          )}
+
+          <p className="text-xs text-blue-700">
+            Some management or diagnostic getters may not be callable by all accounts. The
+            implementation and controller addresses shown here are derived from on-chain state.
+          </p>
         </div>
       ) : (
         <p className="text-sm text-blue-800">

--- a/packages/types/src/adapters/base.ts
+++ b/packages/types/src/adapters/base.ts
@@ -166,6 +166,14 @@ export interface ContractAdapter {
   isViewFunction(functionDetails: ContractFunction): boolean;
 
   /**
+   * Optionally filter which view functions are safe to auto-query without user input.
+   * Adapters can exclude chain-specific management/admin functions that are likely
+   * to revert or require special permissions.
+   * If not implemented, the UI will assume all parameterless view functions are safe.
+   */
+  filterAutoQueryableFunctions?(functions: ContractFunction[]): ContractFunction[];
+
+  /**
    * Queries a view function on a contract.
    * The adapter instance should be pre-configured with the necessary network context.
    *

--- a/packages/types/src/contracts/proxy.ts
+++ b/packages/types/src/contracts/proxy.ts
@@ -16,6 +16,8 @@ export interface ProxyInfo {
   proxyType: string;
   /** Implementation contract address that contains the business logic */
   implementationAddress?: string;
+  /** Admin address for admin-managed proxies (when determinable via storage slots) */
+  adminAddress?: string;
   /** Original proxy contract address provided by the user */
   proxyAddress: string;
   /** Method used to detect the proxy pattern (e.g., 'abi-analysis', 'eip1967-storage', 'direct-call') */


### PR DESCRIPTION
### Summary
Fix proxy implementation resolution for legacy OpenZeppelin Unstructured Storage proxies; surface admin from storage; avoid auto-calling admin-only getters; make Reset Detection use proxy ABI only; prevent reload loop on fatal errors.

Closes #105
