### PR TITLE
ci(release): add file mode guard to block executables/symlinks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,9 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           pnpm run install-deps
 
+      - name: Guard against disallowed file modes (executables/symlinks)
+        run: pnpm run check-file-modes
+
       - name: Make Husky files non-executable for GitHub API compatibility
         run: |
           chmod -x .husky/commit-msg .husky/pre-commit .husky/pre-push 2>/dev/null || true

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "update-deps": "pnpm update -r",
     "update-deps:major": "pnpm update -r --latest",
     "check-deps": "node --no-warnings scripts/check-deps.cjs",
+    "check-file-modes": "node scripts/check-file-modes.cjs",
     "update-export-versions": "node scripts/update-export-versions.cjs",
     "outdated": "pnpm outdated -r",
     "export-app": "node packages/builder/src/export/cli/export-app.cjs",

--- a/scripts/check-file-modes.cjs
+++ b/scripts/check-file-modes.cjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Guard against tracked executables and symlinks that break Changesets commitMode=github-api.
+ * Allows executables only under `.husky/`. Fails on any other 100755 or any 120000 entries.
+ */
+const { execSync } = require('node:child_process');
+
+function run(cmd) {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function main() {
+  const lsOutput = run('git ls-files -s');
+  const lines = lsOutput.split(/\r?\n/);
+
+  const execDisallowed = [];
+  const symlinkDisallowed = [];
+
+  for (const line of lines) {
+    // Format: <mode> <object> <stage>\t<path>
+    // But with -s it's: <mode> <object> <stage> <path>
+    const parts = line.split(/\s+/);
+    if (parts.length < 4) continue;
+    const mode = parts[0];
+    const path = parts.slice(3).join(' ');
+
+    const isHusky = path.startsWith('.husky/');
+
+    if (mode === '100755') {
+      if (!isHusky) execDisallowed.push(path);
+    } else if (mode === '120000') {
+      symlinkDisallowed.push(path);
+    }
+  }
+
+  if (execDisallowed.length === 0 && symlinkDisallowed.length === 0) {
+    console.log('✅ File mode check passed: no disallowed executables or symlinks.');
+    return;
+  }
+
+  if (execDisallowed.length > 0) {
+    console.error('❌ Disallowed executable files (100755) detected:');
+    for (const p of execDisallowed) console.error(` - ${p}`);
+    console.error('\nFix with:');
+    console.error('  git update-index --chmod=-x <file>');
+  }
+
+  if (symlinkDisallowed.length > 0) {
+    console.error('❌ Disallowed symlinks (120000) detected:');
+    for (const p of symlinkDisallowed) console.error(` - ${p}`);
+    console.error('\nReplace symlinks with regular files or proxy modules.');
+  }
+
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

- **ci(release)**: add file mode guard to block executables/symlinks (except .husky) during release

## Rationale
- Changesets with commitMode=github-api rejects symlinks and executable files. This guard fails fast in CI before Changesets tries to commit.

## Details
- Adds  and 
> contracts-ui-builder-monorepo@1.15.0 check-file-modes /Users/ghost/dev/repos/OpenZeppelin/contracts-ui-builder
> node scripts/check-file-modes.cjs

 ELIFECYCLE  Command failed with exit code 1. script
- Invoked in release workflow before Changesets step

## Impact
- Prevents future failures like executable  or symlinked configs; no runtime changes.
