### PR TITLE
ci(builder): fix GitHub API executable files error in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,9 +94,13 @@ jobs:
       - name: Guard against disallowed file modes (executables/symlinks)
         run: pnpm run check-file-modes
 
-      - name: Make Husky files non-executable for GitHub API compatibility
+      - name: Make files non-executable for GitHub API compatibility
         run: |
+          # Make Husky files non-executable
           chmod -x .husky/commit-msg .husky/pre-commit .husky/pre-push 2>/dev/null || true
+
+          # Find and make any other executable files non-executable (except in .husky/)
+          find . -type f -executable ! -path "./.husky/*" ! -path "./node_modules/*" ! -path "./.git/*" -exec chmod -x {} \; 2>/dev/null || true
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Problem

The publish workflow was failing with the following error:

```
Error: Unexpected executable file at packages/builder/src/export/cli/export-app.cjs, GitHub API only supports non-executable files and directories.
```

This happens because the GitHub API (used by Changesets with `commitMode: github-api`) doesn't support executable files when creating commits.

## Solution

Updated the workflow to comprehensively handle executable files that can cause issues with the GitHub API:

1. **Expanded the file permissions fix step** to handle any executable files that might be created during the CI process
2. **Made it future-proof** by using a `find` command that automatically removes executable permissions from all files except those in `.husky/`, `node_modules/`, and `.git/` directories
3. **Kept the existing specific chmod commands** for Husky files for backwards compatibility

## Changes

- Updated `.github/workflows/publish.yml` to automatically detect and fix executable files before the Changesets step
- Changed from targeting specific files to a comprehensive approach that handles any executable files

## Testing

The workflow change ensures that any files that become executable during the CI process (e.g., during tarball unpacking or SLSA provenance building) will be automatically converted to non-executable before the GitHub API operations.

## Impact

- Fixes the immediate publish workflow failure
- Prevents similar issues in the future if other files become executable during CI
- Maintains compatibility with existing Husky setup
