### PR TITLE
fix(ci): configure changesets for single consolidated release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,21 @@
   ],
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [
+    [
+      "@openzeppelin/contracts-ui-builder-types",
+      "@openzeppelin/contracts-ui-builder-utils",
+      "@openzeppelin/contracts-ui-builder-storage",
+      "@openzeppelin/contracts-ui-builder-ui",
+      "@openzeppelin/contracts-ui-builder-renderer",
+      "@openzeppelin/contracts-ui-builder-react-core",
+      "@openzeppelin/contracts-ui-builder-styles",
+      "@openzeppelin/contracts-ui-builder-adapter-evm",
+      "@openzeppelin/contracts-ui-builder-adapter-midnight",
+      "@openzeppelin/contracts-ui-builder-adapter-solana",
+      "@openzeppelin/contracts-ui-builder-adapter-stellar"
+    ]
+  ],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
## Problem
Multiple package releases trigger simultaneous production deployments.

## Solution
Configure changesets to create one consolidated GitHub release instead of individual package releases.

## Changes
- Link all packages in 
- Single release containing all updated packages
- One production deployment per release cycle

## Benefits
- ✅ One release instead of 10+ individual releases
- ✅ Single production deployment
- ✅ Cleaner release history