### PR TITLE
feat(ui): add monad testnet to list of testnet networks

### DIFF
--- a/packages/adapter-evm/src/networks/index.ts
+++ b/packages/adapter-evm/src/networks/index.ts
@@ -19,6 +19,7 @@ import {
   bscTestnet,
   ethereumSepolia,
   lineaSepolia,
+  monadTestnet,
   optimismSepolia,
   polygonAmoy,
   polygonZkEvmCardona,
@@ -55,6 +56,7 @@ export const evmTestnetNetworks: TypedEvmNetworkConfig[] = [
   lineaSepolia,
   scrollSepolia,
   zksyncSepoliaTestnet,
+  monadTestnet,
   // Other testnet networks...
 ];
 
@@ -89,4 +91,5 @@ export {
   lineaSepolia,
   scrollSepolia,
   zksyncSepoliaTestnet,
+  monadTestnet,
 };

--- a/packages/adapter-evm/src/networks/testnet.ts
+++ b/packages/adapter-evm/src/networks/testnet.ts
@@ -273,7 +273,7 @@ export const lineaSepolia: TypedEvmNetworkConfig = {
 export const monadTestnet: TypedEvmNetworkConfig = {
   id: 'monad-testnet',
   exportConstName: 'monadTestnet',
-  name: 'monadTestnet',
+  name: 'Monad Testnet',
   ecosystem: 'evm',
   network: 'monad',
   type: 'testnet',
@@ -281,9 +281,9 @@ export const monadTestnet: TypedEvmNetworkConfig = {
   chainId: 10143,
   rpcUrl: viemMonadTestnet.rpcUrls.default.http[0],
   explorerUrl: 'https://testnet.monadexplorer.com',
-  apiUrl: 'https://api-testnet.monadscan.com/api',
+  apiUrl: 'https://api.etherscan.io/v2/api',
   primaryExplorerApiIdentifier: 'mondad-explorer',
-  supportsEtherscanV2: false,
+  supportsEtherscanV2: true,
   icon: 'monad',
   nativeCurrency: {
     name: 'Monad',

--- a/packages/adapter-evm/src/networks/testnet.ts
+++ b/packages/adapter-evm/src/networks/testnet.ts
@@ -4,6 +4,7 @@ import {
   baseSepolia as viemBaseSepolia,
   bscTestnet as viemBscTestnet,
   lineaSepolia as viemLineaSepolia,
+  monadTestnet as viemMonadTestnet,
   optimismSepolia as viemOptimismSepolia,
   polygonAmoy as viemPolygonAmoy,
   polygonZkEvmCardona as viemPolygonZkEvmCardona,
@@ -267,6 +268,29 @@ export const lineaSepolia: TypedEvmNetworkConfig = {
     decimals: 18,
   },
   viemChain: viemLineaSepolia,
+};
+
+export const monadTestnet: TypedEvmNetworkConfig = {
+  id: 'monad-testnet',
+  exportConstName: 'monadTestnet',
+  name: 'monadTestnet',
+  ecosystem: 'evm',
+  network: 'monad',
+  type: 'testnet',
+  isTestnet: true,
+  chainId: 10143,
+  rpcUrl: viemMonadTestnet.rpcUrls.default.http[0],
+  explorerUrl: 'https://testnet.monadexplorer.com',
+  apiUrl: 'https://api-testnet.monadscan.com/api',
+  primaryExplorerApiIdentifier: 'mondad-explorer',
+  supportsEtherscanV2: false,
+  icon: 'monad',
+  nativeCurrency: {
+    name: 'Monad',
+    symbol: 'MON',
+    decimals: 18,
+  },
+  viemChain: viemMonadTestnet,
 };
 
 // TODO: Add other EVM testnet networks as needed (e.g., Arbitrum Sepolia)


### PR DESCRIPTION
## Description
This PR adds the Monad testnet as a testnet option using the following config

```ts
export const monadTestnet: TypedEvmNetworkConfig = {
  id: 'monad-testnet',
  exportConstName: 'monadTestnet',
  name: 'monadTestnet',
  ecosystem: 'evm',
  network: 'monad',
  type: 'testnet',
  isTestnet: true,
  chainId: 10143,
  rpcUrl: viemMonadTestnet.rpcUrls.default.http[0],
  explorerUrl: 'https://testnet.monadexplorer.com',
  apiUrl: 'https://api-testnet.monadscan.com/api',
  primaryExplorerApiIdentifier: 'mondad-explorer',
  supportsEtherscanV2: false,
  icon: 'monad',
  nativeCurrency: {
    name: 'Monad',
    symbol: 'MON',
    decimals: 18,
  },
  viemChain: viemMonadTestnet,
};
```

## Related Issue
N/A

## Motivation and Context
Helps encourage usage from the Monad community in preparation for mainnet

## How Has This Been Tested?
✅ - UI displays network and config correctly 
❌ - I'm having issues getting the `https://api-testnet.monadexplorer.com/api` to work. I keep getting an error message about an invalid API key even though it's fresh from Etherescan.io. Exact error:
```json
{
	"status": "0",
	"message": "NOTOK",
	"result": "Invalid API Key (#err2)|MONAD1"
}
```
If someone can also test their API key it might help us figure out if we need to create a ticket with the Monad explorer. My explorer API key works with other networks so I'm afraid it is an issue with Etherscan <> Mondscan 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 