### PR TITLE
fix(ui): ensure array add-item works with default 0

### DIFF
--- a/.changeset/polite-words-laugh.md
+++ b/.changeset/polite-words-laugh.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-ui-builder-ui': patch
+---
+
+snapshot pre-append and fallback setValue to fix add-item with default 0 in ArrayField


### PR DESCRIPTION
Isolate the snapshot+fallback ArrayField fix so Add Item works when default is 0.

- Snapshot array values before append to avoid stale reads
- Fallback setValue if immediate length check doesn’t reflect append
- Localized to 
- Includes comment with rationale/backstory

This PR contains only the minimal change and the generated changeset.