### PR TITLE
fix(builder): restore version 0.7.1 packages from orphaned changeset release

### DIFF
--- a/.changeset/curly-vans-beg.md
+++ b/.changeset/curly-vans-beg.md
@@ -1,5 +1,0 @@
----
-'@openzeppelin/contracts-ui-builder-ui': patch
----
-
-allow zero values in ArrayField required validation

--- a/.changeset/polite-words-laugh.md
+++ b/.changeset/polite-words-laugh.md
@@ -1,5 +1,0 @@
----
-'@openzeppelin/contracts-ui-builder-ui': patch
----
-
-snapshot pre-append and fallback setValue to fix add-item with default 0 in ArrayField

--- a/.changeset/whole-bees-press.md
+++ b/.changeset/whole-bees-press.md
@@ -1,5 +1,0 @@
----
-'@openzeppelin/contracts-ui-builder-adapter-evm': patch
----
-
-clean up redundant ternary in array field validation

--- a/packages/adapter-evm/CHANGELOG.md
+++ b/packages/adapter-evm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openzeppelin/transaction-form-adapter-evm
 
+## 0.7.1
+
+### Patch Changes
+
+- [#137](https://github.com/OpenZeppelin/contracts-ui-builder/pull/137) [`73db143`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/73db1436f5c6f44062a39f262bad9a542fb85bb9) Thanks [@pasevin](https://github.com/pasevin)! - clean up redundant ternary in array field validation
+
+- Updated dependencies [[`73db143`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/73db1436f5c6f44062a39f262bad9a542fb85bb9), [`49d7d6c`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/49d7d6c38d1890a67dfbf514161e71f46849a123)]:
+  - @openzeppelin/contracts-ui-builder-ui@0.7.1
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/adapter-evm/package.json
+++ b/packages/adapter-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/contracts-ui-builder-adapter-evm",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "EVM Adapter for Contracts UI Builder",
   "keywords": [

--- a/packages/adapter-midnight/CHANGELOG.md
+++ b/packages/adapter-midnight/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openzeppelin/transaction-form-adapter-midnight
 
+## 0.7.1
+
+### Patch Changes
+
+- Updated dependencies [[`73db143`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/73db1436f5c6f44062a39f262bad9a542fb85bb9), [`49d7d6c`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/49d7d6c38d1890a67dfbf514161e71f46849a123)]:
+  - @openzeppelin/contracts-ui-builder-ui@0.7.1
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/adapter-midnight/package.json
+++ b/packages/adapter-midnight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/contracts-ui-builder-adapter-midnight",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Midnight Adapter for Contracts UI Builder",
   "keywords": [
     "openzeppelin",

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @openzeppelin/transaction-form-builder-core
 
+## 0.7.1
+
+### Patch Changes
+
+- Updated dependencies [[`73db143`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/73db1436f5c6f44062a39f262bad9a542fb85bb9), [`49d7d6c`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/49d7d6c38d1890a67dfbf514161e71f46849a123), [`73db143`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/73db1436f5c6f44062a39f262bad9a542fb85bb9)]:
+  - @openzeppelin/contracts-ui-builder-ui@0.7.1
+  - @openzeppelin/contracts-ui-builder-adapter-evm@0.7.1
+  - @openzeppelin/contracts-ui-builder-adapter-midnight@0.7.1
+  - @openzeppelin/contracts-ui-builder-renderer@0.7.1
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openzeppelin/contracts-ui-builder-app",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "bin": {
     "export-app": "src/export/cli/export-app.cjs"

--- a/packages/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
+++ b/packages/builder/src/export/__tests__/__snapshots__/ExportSnapshotTests.test.ts.snap
@@ -276,11 +276,11 @@ exports[`Export Snapshot Tests > EVM Export Snapshots > should match snapshot fo
 exports[`Export Snapshot Tests > EVM Export Snapshots > should match snapshot for package.json structure > package-json-evm 1`] = `
 {
   "dependencies": {
-    "@openzeppelin/contracts-ui-builder-adapter-evm": "^0.7.0",
+    "@openzeppelin/contracts-ui-builder-adapter-evm": "^0.7.1",
     "@openzeppelin/contracts-ui-builder-react-core": "^0.7.0",
-    "@openzeppelin/contracts-ui-builder-renderer": "^0.7.0",
+    "@openzeppelin/contracts-ui-builder-renderer": "^0.7.1",
     "@openzeppelin/contracts-ui-builder-types": "^0.4.0",
-    "@openzeppelin/contracts-ui-builder-ui": "^0.7.0",
+    "@openzeppelin/contracts-ui-builder-ui": "^0.7.1",
     "@openzeppelin/contracts-ui-builder-utils": "^0.7.0",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.17.0",
@@ -323,11 +323,11 @@ exports[`Export Snapshot Tests > Solana Export Snapshots > should match snapshot
 exports[`Export Snapshot Tests > Solana Export Snapshots > should match snapshot for package.json with Solana dependencies > package-json-solana 1`] = `
 {
   "dependencies": {
-    "@openzeppelin/contracts-ui-builder-adapter-evm": "^0.7.0",
+    "@openzeppelin/contracts-ui-builder-adapter-evm": "^0.7.1",
     "@openzeppelin/contracts-ui-builder-react-core": "^0.7.0",
-    "@openzeppelin/contracts-ui-builder-renderer": "^0.7.0",
+    "@openzeppelin/contracts-ui-builder-renderer": "^0.7.1",
     "@openzeppelin/contracts-ui-builder-types": "^0.4.0",
-    "@openzeppelin/contracts-ui-builder-ui": "^0.7.0",
+    "@openzeppelin/contracts-ui-builder-ui": "^0.7.1",
     "@openzeppelin/contracts-ui-builder-utils": "^0.7.0",
     "@tanstack/react-query": "^5.0.0",
     "@wagmi/core": "^2.17.0",

--- a/packages/builder/src/export/versions.ts
+++ b/packages/builder/src/export/versions.ts
@@ -6,14 +6,14 @@
  */
 
 export const packageVersions = {
-  '@openzeppelin/contracts-ui-builder-adapter-evm': '0.7.0',
-  '@openzeppelin/contracts-ui-builder-adapter-midnight': '0.7.0',
+  '@openzeppelin/contracts-ui-builder-adapter-evm': '0.7.1',
+  '@openzeppelin/contracts-ui-builder-adapter-midnight': '0.7.1',
   '@openzeppelin/contracts-ui-builder-adapter-solana': '0.7.0',
   '@openzeppelin/contracts-ui-builder-adapter-stellar': '0.7.0',
   '@openzeppelin/contracts-ui-builder-react-core': '0.7.0',
-  '@openzeppelin/contracts-ui-builder-renderer': '0.7.0',
+  '@openzeppelin/contracts-ui-builder-renderer': '0.7.1',
   '@openzeppelin/contracts-ui-builder-storage': '0.7.0',
   '@openzeppelin/contracts-ui-builder-types': '0.4.0',
-  '@openzeppelin/contracts-ui-builder-ui': '0.7.0',
+  '@openzeppelin/contracts-ui-builder-ui': '0.7.1',
   '@openzeppelin/contracts-ui-builder-utils': '0.7.0',
 };

--- a/packages/renderer/CHANGELOG.md
+++ b/packages/renderer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openzeppelin/transaction-form-renderer
 
+## 0.7.1
+
+### Patch Changes
+
+- Updated dependencies [[`73db143`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/73db1436f5c6f44062a39f262bad9a542fb85bb9), [`49d7d6c`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/49d7d6c38d1890a67dfbf514161e71f46849a123)]:
+  - @openzeppelin/contracts-ui-builder-ui@0.7.1
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/contracts-ui-builder-renderer",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "A specialized library for rendering customizable transaction forms for blockchain applications.",
   "type": "module",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openzeppelin/transaction-form-ui
 
+## 0.7.1
+
+### Patch Changes
+
+- [#137](https://github.com/OpenZeppelin/contracts-ui-builder/pull/137) [`73db143`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/73db1436f5c6f44062a39f262bad9a542fb85bb9) Thanks [@pasevin](https://github.com/pasevin)! - allow zero values in ArrayField required validation
+
+- [#139](https://github.com/OpenZeppelin/contracts-ui-builder/pull/139) [`49d7d6c`](https://github.com/OpenZeppelin/contracts-ui-builder/commit/49d7d6c38d1890a67dfbf514161e71f46849a123) Thanks [@pasevin](https://github.com/pasevin)! - snapshot pre-append and fallback setValue to fix add-item with default 0 in ArrayField
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/contracts-ui-builder-ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "Shared React UI components for the OpenZeppelin Contracts UI Builder.",
   "type": "module",


### PR DESCRIPTION
## Problem

PR #140 (Version Packages) was automatically closed, but the individual PRs #137 and #139 were merged directly to main. This left the codebase in an inconsistent state where:

- ✅ Code fixes are on main 
- ❌ Version bumps (0.7.1) and changeset cleanup are missing
- ❌ Packages never got published to npm

## Root Cause

The changesets release workflow was interrupted. The version bump commit (68fffcf) exists on the `changeset-release/main` branch but was orphaned when PR #140 was closed.

## Solution

This PR cherry-picks the orphaned version bump commit (68fffcf) from `changeset-release/main` to restore:

- ✅ Version bumps to 0.7.1 for affected packages
- ✅ Proper CHANGELOG updates
- ✅ Changeset file cleanup
- ✅ Export version synchronization

## Changes

- Restores package versions to 0.7.1 for: ui, adapter-evm, adapter-midnight, renderer, builder
- Removes processed changeset files: curly-vans-beg.md, polite-words-laugh.md, whole-bees-press.md  
- Updates CHANGELOGs with proper release notes
- Synchronizes export versions.ts file

This will allow the release process to complete properly and publish the 0.7.1 packages to npm.