### PR TITLE
fix: stabilize arrays and autosave for hardcoded values

### DIFF
--- a/.changeset/ten-rooms-bow.md
+++ b/.changeset/ten-rooms-bow.md
@@ -1,0 +1,5 @@
+---
+'@openzeppelin/contracts-ui-builder-ui': patch
+---
+
+stabilize array ops across contexts

--- a/packages/builder/src/components/ContractsUIBuilder/hooks/builder/useAutoSave.ts
+++ b/packages/builder/src/components/ContractsUIBuilder/hooks/builder/useAutoSave.ts
@@ -252,6 +252,17 @@ export function useAutoSave(isLoadingSavedConfigRef: React.RefObject<boolean>): 
     autoSaveRef.current = autoSave;
   }, [autoSave]);
 
+  // Single composite key to detect changes across the full formConfig and relevant contract state.
+  // Perf note: JSON.stringify is O(n) in config size and acceptable for typical forms.
+  // If profiling shows this hot, switch to a store-level numeric revision counter instead,
+  // e.g. `formConfigRevision` incremented on any formConfig/definition change, and depend on that.
+  const autoSaveKey = JSON.stringify({
+    formConfig: state.formConfig,
+    contractDefinitionJson: state.contractState.definitionJson,
+    contractDefinitionSource: state.contractState.source,
+    contractDefinitionMetadata: state.contractState.metadata,
+  });
+
   /**
    * Effect to schedule auto-save operations
    *
@@ -271,11 +282,8 @@ export function useAutoSave(isLoadingSavedConfigRef: React.RefObject<boolean>): 
       selectedNetworkConfigId: state.selectedNetworkConfigId,
       contractAddress: state.contractState.address,
       selectedFunction: state.selectedFunction,
-      formConfig: state.formConfig,
-      // Include contract definition fields to trigger auto-save when they change
-      contractDefinitionJson: state.contractState.definitionJson,
-      contractDefinitionSource: state.contractState.source,
-      contractDefinitionMetadata: state.contractState.metadata,
+      // Single composite key capturing all relevant formConfig + contract definition changes
+      autoSaveKey,
     },
   ]);
 


### PR DESCRIPTION
### Summary
- Fix array field persistence and UI consistency in preview and wizard flows
- Trigger autosave reliably when editing hardcoded array values (add/remove/edit)
- Consolidate autosave dependency tracking to a single composite key

### Key Changes
- ui (`ArrayField.tsx`):
  - Deterministic append/remove via snapshot+fallback and replace()
  - Context-agnostic operation (works with/without FormProvider)
  - Sync effect guarded by `isReplacingRef`; microtask reset
  - Added rationale comment for future maintenance
- builder (`FieldEditor.tsx`):
  - Immediate store updates for `hardcodedValue` with micro-delay
  - Prevent duplicate structural events using `previousHardcodedRef` + deepEqual
  - Preserve hardcoded value on field resets when appropriate
- builder (`useAutoSave.ts`):
  - Use single `autoSaveKey` (JSON.stringify) to capture all relevant changes

### Testing
- Manually validated in preview and wizard hardcoded flows:
  - Adding/removing zeros persists and triggers autosave
  - Removing hardcoded items works reliably
  - Subsequent array edits trigger autosave
- Monorepo format/lint run clean; adapter lint passes; export snapshot tests updated and green

### Notes
- Changeset included for release.
