### PR TITLE
fix(adapter-evm): resolve @wagmi/core version conflicts causing CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
       "@types/react": "^19.1.8",
       "prettier": "3.6.2",
       "prettier-plugin-tailwindcss": "0.6.14",
-      "@ianvs/prettier-plugin-sort-imports": "4.5.1"
+      "@ianvs/prettier-plugin-sort-imports": "4.5.1",
+      "@wagmi/core": "^2.20.3"
     }
   },
   "dependencies": {

--- a/packages/adapter-evm/package.json
+++ b/packages/adapter-evm/package.json
@@ -53,7 +53,7 @@
     "@openzeppelin/contracts-ui-builder-utils": "workspace:^",
     "@openzeppelin/relayer-sdk": "1.1.0",
     "@wagmi/connectors": "5.7.13",
-    "@wagmi/core": "^2.18.1",
+    "@wagmi/core": "^2.20.3",
     "lodash": "^4.17.21",
     "lucide-react": "^0.510.0",
     "react-hook-form": "^7.62.0"

--- a/packages/adapter-evm/src/config.ts
+++ b/packages/adapter-evm/src/config.ts
@@ -20,7 +20,7 @@ export const evmAdapterConfig: AdapterConfig = {
       // Core EVM libraries
       // Wallet connection libraries
       wagmi: '^2.15.0',
-      '@wagmi/core': '^2.17.0',
+      '@wagmi/core': '^2.20.3',
       viem: '^2.28.0',
       '@tanstack/react-query': '^5.0.0',
       // Utility library

--- a/packages/adapter-evm/src/wallet/components/EvmWalletUiRoot.tsx
+++ b/packages/adapter-evm/src/wallet/components/EvmWalletUiRoot.tsx
@@ -1,5 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { WagmiProvider, type Config as WagmiConfig } from 'wagmi';
+import { createConfig, http } from '@wagmi/core';
+import { mainnet } from 'viem/chains';
+import { WagmiProvider } from 'wagmi';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import type { EcosystemReactUiProviderProps } from '@openzeppelin/contracts-ui-builder-types';
@@ -15,13 +17,14 @@ const stableQueryClient = new QueryClient();
 
 // Create a minimal, default WagmiConfig to use when no other config is ready.
 // This ensures WagmiProvider can always be mounted with a valid config object.
-const minimalDefaultWagmiConfig = {
-  chains: [], // No chains initially
-  transports: {},
-  // connectors: [], // Wagmi core createConfig requires connectors, but provider might be more lenient
-  // Or provide a dummy connector if absolutely needed by WagmiProvider for mount.
-  // For now, relying on WagmiProvider handling minimal config gracefully.
-} as unknown as WagmiConfig; // Cast because a true minimal config might not satisfy full Config type
+// Uses mainnet as a minimal default chain with HTTP transport.
+const minimalDefaultWagmiConfig = createConfig({
+  chains: [mainnet], // At least one chain is required in wagmi v2.20+
+  connectors: [], // Empty connectors array
+  transports: {
+    [mainnet.id]: http(), // Basic HTTP transport for the default chain
+  },
+});
 
 export const EvmWalletUiRoot: React.FC<EcosystemReactUiProviderProps> = ({ children }) => {
   const [managerState, setManagerState] = useState<EvmUiKitManagerState>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   prettier: 3.6.2
   prettier-plugin-tailwindcss: 0.6.14
   '@ianvs/prettier-plugin-sort-imports': 4.5.1
+  '@wagmi/core': ^2.20.3
 
 importers:
 
@@ -147,10 +148,10 @@ importers:
         version: 1.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@wagmi/connectors':
         specifier: 5.7.13
-        version: 5.7.13(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.11)(@wagmi/core@2.19.0(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 5.7.13(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.11)(@wagmi/core@2.20.3(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@wagmi/core':
-        specifier: ^2.18.1
-        version: 2.19.0(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: ^2.20.3
+        version: 2.20.3(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -3508,7 +3509,7 @@ packages:
   '@wagmi/connectors@5.7.13':
     resolution: {integrity: sha512-FHvqlECFJAoWOm1PEvVY1Zo2iy9tfE1CB97ivVjSSYb4UGAHvRxg4cb2gXTfsF7z1a3QxtU/Q0VI1m4y0NP0gg==}
     peerDependencies:
-      '@wagmi/core': 2.17.0
+      '@wagmi/core': ^2.20.3
       typescript: '>=5.0.4'
       viem: 2.x
     peerDependenciesMeta:
@@ -3518,22 +3519,10 @@ packages:
   '@wagmi/connectors@5.9.9':
     resolution: {integrity: sha512-6+eqU7P2OtxU2PkIw6kHojfYYUJykYG2K5rSkzVh29RDCAjhJqGEZW5f1b8kV5rUBORip1NpST8QTBNi96JHGQ==}
     peerDependencies:
-      '@wagmi/core': 2.20.3
+      '@wagmi/core': ^2.20.3
       typescript: '>=5.0.4'
       viem: 2.x
     peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@wagmi/core@2.19.0':
-    resolution: {integrity: sha512-lI57q6refAtNU6xnk/oyOpbEtEiwQ6g4rR+C9FEx8Gn2hZlfoyyksndrl6hIKlMBK+UkkKso3VwR5DI65j/5XQ==}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.0.0'
-      typescript: '>=5.0.4'
-      viem: 2.x
-    peerDependenciesMeta:
-      '@tanstack/query-core':
-        optional: true
       typescript:
         optional: true
 
@@ -11837,13 +11826,13 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@wagmi/connectors@5.7.13(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.11)(@wagmi/core@2.19.0(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@5.7.13(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.11)(@wagmi/core@2.20.3(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@coinbase/wallet-sdk': 4.3.0
       '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.19.0(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.20.3(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.11)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.11)(bufferutil@4.0.9)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
       viem: 2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -11920,21 +11909,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-
-  '@wagmi/core@2.19.0(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.9.2)
-      viem: 2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zustand: 5.0.0(@types/react@19.1.11)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
-    optionalDependencies:
-      '@tanstack/query-core': 5.85.5
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
 
   '@wagmi/core@2.20.3(@tanstack/query-core@5.85.5)(@types/react@19.1.11)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.34.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:


### PR DESCRIPTION
## Problem

GitHub Actions CI was failing during the `publish-rc` workflow with TypeScript errors related to conflicting `@wagmi/core` versions:

```
error TS2322: Type 'import(".../@wagmi+core@2.19.0/...").Config' is not assignable to type 'import(".../@wagmi+core@2.20.3/...").Config'.
```

The issue was caused by pnpm resolving different versions of `@wagmi/core` (2.19.0 vs 2.20.3) for different dependencies, leading to type incompatibilities in `EvmWalletUiRoot.tsx`.

## Solution

1. **Added pnpm override** in root `package.json` to force consistent `@wagmi/core` version resolution:
   ```json
   "@wagmi/core": "^2.20.3"
   ```

2. **Updated version specifications** across the EVM adapter package:
   - Updated `packages/adapter-evm/package.json` dependency
   - Updated `packages/adapter-evm/src/config.ts` export configuration

3. **Fixed type compatibility issues** in `EvmWalletUiRoot.tsx`:
   - Replaced manual config object with proper `createConfig()` call from `@wagmi/core`
   - Added required mainnet chain and HTTP transport (v2.20+ requirement)
   - Removed unused imports

## Testing

- ✅ EVM adapter typecheck now passes
- ✅ All package dependencies resolve to consistent `@wagmi/core@2.20.3`
- ✅ Pre-commit and pre-push hooks pass successfully

## Impact

- Resolves CI failures in the `publish-rc` workflow
- Ensures consistent wagmi dependency versions across the monorepo
- Maintains backward compatibility while following updated wagmi v2.20+ API requirements
