### PR TITLE
fix(export): escape App.tsx title in export

### DIFF
--- a/packages/builder/src/export/codeTemplates/TemplateTypes.ts
+++ b/packages/builder/src/export/codeTemplates/TemplateTypes.ts
@@ -68,6 +68,11 @@ export interface AppComponentTemplateParams extends BaseTemplateParams {
   functionId: string;
 
   /**
+   * HTML-escaped function ID safe for JSX text nodes
+   */
+  functionIdEscaped?: string;
+
+  /**
    * The current year for copyright notices
    */
   currentYear: number;

--- a/packages/builder/src/export/codeTemplates/app-component.template.tsx
+++ b/packages/builder/src/export/codeTemplates/app-component.template.tsx
@@ -45,7 +45,7 @@ export function App() {
             <img src="/OZ-Logo-BlackBG.svg" alt="OpenZeppelin Logo" className="h-6 w-auto" />
             <div className="h-5 border-l border-gray-300 mx-1"></div>
             <div>
-              <h1 className="text-base font-medium">@@function-id@@</h1>
+              <h1 className="text-base font-medium">@@function-id-escaped@@</h1>
               <p className="text-xs text-muted-foreground">
                 Form for interacting with blockchain contracts
               </p>

--- a/packages/builder/src/export/generators/AppCodeGenerator.ts
+++ b/packages/builder/src/export/generators/AppCodeGenerator.ts
@@ -1,4 +1,4 @@
-import { capitalize } from 'lodash';
+import { capitalize, escape as escapeHtml } from 'lodash';
 
 import {
   Ecosystem,
@@ -283,6 +283,7 @@ export class AppCodeGenerator {
     // Create parameters for the template
     const params: AppComponentTemplateParams & Record<string, unknown> = {
       functionId,
+      functionIdEscaped: escapeHtml(functionId),
       currentYear: new Date().getFullYear(),
       adapterClassName,
       adapterPackageName,


### PR DESCRIPTION
# Escape App title in exported App.tsx

## Summary
- Use lodash _.escape to render functionId safely in App header.
- Updates template to use @@function-id-escaped@@.
- Prevents JSX breaking for Stellar titles like: Map<ScSymbol, Bytes>.

## Changes
- builder: AppCodeGenerator uses lodash escape for functionIdEscaped.
- builder: app-component.template.tsx uses escaped placeholder.
- builder: TemplateTypes includes optional functionIdEscaped.

## Tests
- Existing export snapshot tests pass; snapshots updated automatically by CI script.

## Notes
- Follows preference to use lodash utilities where possible.
