### PR TITLE
Strip logging in prod/staging; disable logger outside dev

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -152,6 +152,8 @@ const baseConfig = [
       'unused-imports': unusedImportsPlugin,
     },
     rules: {
+      // Disallow direct console usage; use logger utility instead
+      'no-console': 'error',
       'import/first': 'error',
       'import/newline-after-import': 'error',
       'import/no-duplicates': 'error',
@@ -165,6 +167,38 @@ const baseConfig = [
           argsIgnorePattern: '^_',
         },
       ],
+    },
+  },
+
+  // Test files override: allow console usage in tests
+  {
+    files: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx', '**/*.test.js', '**/*.test.jsx'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+
+  // Story files override: allow console usage in Storybook stories
+  {
+    files: ['**/*.stories.tsx', '**/*.stories.jsx', '**/*.stories.ts', '**/*.stories.js'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+
+  // Adapter Stellar scripts override: allow console usage in Node scripts
+  {
+    files: ['packages/adapter-stellar/scripts/**/*.js'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+
+  // Adapter Stellar validator override: allow console in the type coverage validator
+  {
+    files: ['packages/adapter-stellar/src/mapping/type-coverage-validator.ts'],
+    rules: {
+      'no-console': 'off',
     },
   },
 

--- a/packages/builder/src/export/templates/typescript-react-vite/vite.config.ts
+++ b/packages/builder/src/export/templates/typescript-react-vite/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
@@ -22,9 +22,11 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     sourcemap: true,
+    minify: 'esbuild',
+    esbuild: mode === 'development' ? {} : { drop: ['console', 'debugger'] },
   },
   server: {
     port: 3000,
     open: true,
   },
-});
+}));

--- a/packages/builder/vite.config.ts
+++ b/packages/builder/vite.config.ts
@@ -20,7 +20,7 @@ import templatePlugin from './vite.template-plugin';
  */
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
     tailwindcss(),
@@ -68,5 +68,8 @@ export default defineConfig({
     chunkSizeWarningLimit: 1000,
     // Reduce source map generation to save memory
     sourcemap: false,
+    // Remove console and debugger in staging/production builds
+    minify: 'esbuild',
+    esbuild: mode === 'development' ? {} : { drop: ['console', 'debugger'] },
   },
-});
+}));

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -13,7 +13,7 @@ interface LoggerOptions {
 class Logger {
   private static instance: Logger;
   private options: LoggerOptions = {
-    enabled: true,
+    enabled: getDefaultLoggerEnabled(),
     level: 'debug',
   };
 
@@ -46,27 +46,61 @@ class Logger {
 
   debug(system: string, message: string, ...args: unknown[]): void {
     if (this.shouldLog('debug')) {
+      // eslint-disable-next-line no-console
       console.log(this.formatMessage('debug', system, message), ...args);
     }
   }
 
   info(system: string, message: string, ...args: unknown[]): void {
     if (this.shouldLog('info')) {
+      // eslint-disable-next-line no-console
       console.log(this.formatMessage('info', system, message), ...args);
     }
   }
 
   warn(system: string, message: string, ...args: unknown[]): void {
     if (this.shouldLog('warn')) {
+      // eslint-disable-next-line no-console
       console.warn(this.formatMessage('warn', system, message), ...args);
     }
   }
 
   error(system: string, message: string, ...args: unknown[]): void {
     if (this.shouldLog('error')) {
+      // eslint-disable-next-line no-console
       console.error(this.formatMessage('error', system, message), ...args);
     }
   }
 }
 
 export const logger = Logger.getInstance();
+
+/**
+ * Determine whether logging should be enabled by default.
+ *
+ * - In Vite/browser contexts, use `import.meta.env.DEV`.
+ * - In Node/tsup contexts, use `process.env.NODE_ENV`.
+ *
+ * Defaults to disabled outside development to avoid runtime overhead and noise.
+ */
+function getDefaultLoggerEnabled(): boolean {
+  // Vite/browser: `import.meta.env.DEV` is true in dev, false in prod builds
+  try {
+    // Use a narrow, typed access pattern to avoid depending on Vite types in this package
+    const viteEnvDev = (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV;
+    if (typeof viteEnvDev === 'boolean') {
+      return viteEnvDev;
+    }
+  } catch {
+    // Ignore environments where import.meta is not available or lacks env
+  }
+
+  // Node/tsup: consider development as the only environment with default logging
+  if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
+    const nodeEnv = process.env.NODE_ENV;
+    return nodeEnv === 'development' || nodeEnv === undefined;
+  }
+
+  // Safe fallback: disabled
+  return false;
+}


### PR DESCRIPTION
# Strip logging in prod/staging builds and disable logger in prod

## Changes
- Added esbuild drop of console and debugger when mode != development in builder and export template Vite configs.
- Default-disabled logger outside development via env detection in packages/utils/src/logger.ts.
- Enforced ESLint no-console in source with overrides for tests, stories, and adapter-stellar scripts/validator.

## Verification
- Build: pnpm --filter=@openzeppelin/contracts-ui-builder-app build
- Preview: pnpm --filter=@openzeppelin/contracts-ui-builder-app preview
- Bundle check: rg -n "console\." packages/builder/dist || echo none

## Impact
- Dev unchanged; staging/production strip logs and logger disabled by default.
