### PR TITLE
fix(adapter-stellar): surface NO_WASM error and add manual input guidance

### DIFF
--- a/packages/adapter-stellar/src/adapter.ts
+++ b/packages/adapter-stellar/src/adapter.ts
@@ -118,6 +118,29 @@ export class StellarAdapter implements ContractAdapter {
   }
 
   // --- Contract Loading --- //
+  /**
+   * NOTE about artifact inputs (Midnight-style multi-input guidance):
+   *
+   * The Builder renders the contract definition step using whatever fields the
+   * adapter returns here. EVM uses one optional ABI field; Midnight provides
+   * multiple fields. Stellar can follow the Midnight pattern to support
+   * multiple artifact sources when we add manual-spec support:
+   *
+   * - Keep `contractAddress` (required)
+   * - Add optional `contractSpecJson` (type: `code-editor`, language: `json`)
+   *   for pasting Soroban spec JSON
+   * - Add optional `contractWasm` (type: `textarea` or `file-upload` if
+   *   available) for base64 or uploaded `.wasm`
+   *
+   * When those fields are added:
+   * - Extend `validateAndConvertStellarArtifacts(...)` to accept
+   *   `{ contractAddress, contractSpecJson?, contractWasm? }`
+   * - In the loader, branch: if `contractSpecJson`/`contractWasm` provided,
+   *   derive a schema locally and set `source: 'manual'` with
+   *   `contractDefinitionOriginal` to the raw user-provided content. This
+   *   ensures auto-save captures and restores the manual contract definition
+   *   exactly like the EVM/Midnight flows.
+   */
   public getContractDefinitionInputs(): FormFieldType[] {
     return [
       {

--- a/packages/adapter-stellar/src/contract/loader.ts
+++ b/packages/adapter-stellar/src/contract/loader.ts
@@ -411,23 +411,22 @@ export async function loadStellarContractWithMetadata(
 }
 
 /**
- * Integration points for manual spec/wasm inputs (future work):
+ * Integration points for manual contract definition input (future work):
  *
- * 1) Import Soroban Spec JSON (parity with EVM ABI import):
- *    - Add a new loader path that accepts a spec JSON object/string.
- *    - Convert with `transformStellarSpecToSchema()` to a `ContractSchema`.
- *    - Persist via existing auto-save flow by returning `source: 'manual'` and
- *      setting `contractDefinitionOriginal` to the raw JSON provided.
- *    - Suggested API: `loadStellarContractFromSpecJson(specJson, networkConfig)`.
+ * Single Input with Auto-Detection (simplified UX):
+ *    - Add a new loader path: `loadStellarContractFromDefinition(definition, networkConfig)`
+ *    - Auto-detect content type using magic bytes and structure:
+ *      - Wasm binary: starts with magic bytes `[0x00, 0x61, 0x73, 0x6D]` (`\0asm`)
+ *      - JSON spec: valid JSON array with Soroban spec entry objects
+ *    - For JSON: Parse and validate, use `transformStellarSpecToSchema()` to build schema
+ *    - For Wasm: Extract embedded spec from binary locally (no RPC), then build schema
+ *    - Return `{ schema, source: 'manual' }` with `contractDefinitionOriginal` set to
+ *      the raw input (JSON string or Wasm binary) for auto-save restoration
  *
- * 2) Import compiled Wasm (parity with Midnight adapter manual inputs):
- *    - Parse embedded spec from `.wasm` locally (no RPC) to build the schema.
- *    - Return `{ schema, source: 'manual' }` similarly to spec JSON path.
- *    - Suggested API: `loadStellarContractFromWasm(wasmBytes, networkConfig)`.
- *
- * The builder UI can route these manual loaders based on user action (upload
- * spec/wasm), and the auto-save system will store the resulting schema and
- * `contractDefinitionOriginal` so the configuration restores seamlessly.
+ * The builder UI provides a single input field (code editor with file upload support)
+ * that accepts either format, eliminating user confusion about format selection.
+ * The auto-save system will store the resulting schema and `contractDefinitionOriginal`
+ * so the configuration restores seamlessly.
  */
 
 /**


### PR DESCRIPTION
## Summary

Fixes Stellar contract loading errors when contracts have no published Wasm/definition on the network by implementing Laboratory-style error handling and adding guidance for future manual input support.

## Changes

### Error Handling
- **Fixed NO_WASM error**: Catch specific SDK error `"Cannot destructure property 'length'"` in `loadStellarContractFromAddress`
- **User-friendly messaging**: Surface clear error message instead of cryptic SDK error
- **Laboratory parity**: Matches error handling approach used in Stellar Laboratory

### Future Manual Input Guidance
- **Single input approach**: Added comments for `contractDefinition` field with auto-detection
- **Auto-detection logic**: Support both Soroban spec JSON and compiled Wasm through single input
- **Integration points**: Detailed guidance for seamless auto-save compatibility

## Testing

- ✅ Simple contract (CB5IIF2KQPOS3UTQASOQTP5R3GEEYNY3CLIRNFV4YDBJHV23ER7IWPBX) loads successfully
- ✅ Complex contract (CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC) shows clear error message instead of crashing

## Related

- Linear ticket: [PLAT-6936](https://linear.app/openzeppelin-development/issue/PLAT-6936/stellar-adapter-feature-manual-spec-json-and-wasm-input-support)
- Reference: Stellar Laboratory error handling pattern
