### PR TITLE
fix(adapter-evm): robust Sourcify fetch; docs: deeplink provider notes

### DIFF
--- a/packages/adapter-evm/src/abi/sourcify.ts
+++ b/packages/adapter-evm/src/abi/sourcify.ts
@@ -11,9 +11,23 @@ export interface SourcifyAbiResult {
 
 const SOURCIFY_BASE = 'https://repo.sourcify.dev';
 
-function buildSourcifyAbiUrl(chainId: number, address: string): string {
-  const checksum = address.toLowerCase();
-  return `${SOURCIFY_BASE}/contracts/full_match/${chainId}/${checksum}/metadata.json`;
+function buildSourcifyAbiUrlCandidates(chainId: number, address: string): string[] {
+  // Sourcify stores addresses in lowercase on disk, but be defensive and try both
+  const addrLower = address.toLowerCase();
+  const addrOriginal = address;
+
+  // The repo host supports explicit match types only: full_match and partial_match.
+  // The "any" route is not valid on repo.sourcify.dev and triggers OpenAPI validation errors.
+  const categories = ['full_match', 'partial_match'] as const;
+  const addrs = [addrLower, addrOriginal];
+
+  const urls: string[] = [];
+  for (const category of categories) {
+    for (const addr of addrs) {
+      urls.push(`${SOURCIFY_BASE}/contracts/${category}/${chainId}/${addr}/metadata.json`);
+    }
+  }
+  return urls;
 }
 
 /**
@@ -29,29 +43,42 @@ export async function loadAbiFromSourcify(
   networkConfig: TypedEvmNetworkConfig,
   timeoutMs = 4000
 ): Promise<SourcifyAbiResult> {
-  const url = buildSourcifyAbiUrl(networkConfig.chainId, address);
+  const candidates = buildSourcifyAbiUrlCandidates(networkConfig.chainId, address);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    logger.info('loadAbiFromSourcify', `Fetching metadata from ${url}`);
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`Sourcify request failed: ${response.status} ${response.statusText}`);
-    }
-    const metadata = (await response.json()) as {
-      output?: { abi?: AbiItem[] };
-      contractName?: string;
-    };
+    let lastError: Error | null = null;
+    for (const url of candidates) {
+      try {
+        logger.info('loadAbiFromSourcify', `Fetching metadata from ${url}`);
+        const response = await fetch(url, { signal: controller.signal });
+        if (!response.ok) {
+          lastError = new Error(
+            `Sourcify request failed: ${response.status} ${response.statusText} (${url})`
+          );
+          continue; // try next candidate
+        }
+        const metadata = (await response.json()) as {
+          output?: { abi?: AbiItem[] };
+          contractName?: string;
+        };
 
-    const abi = metadata?.output?.abi;
-    if (!abi || !Array.isArray(abi)) {
-      throw new Error('Sourcify metadata did not include a valid ABI array');
-    }
+        const abi = metadata?.output?.abi;
+        if (!abi || !Array.isArray(abi)) {
+          lastError = new Error('Sourcify metadata did not include a valid ABI array');
+          continue; // try next candidate
+        }
 
-    const contractName = metadata.contractName || `Contract_${address.substring(0, 6)}`;
-    const schema = transformAbiToSchema(abi, contractName, address);
-    return { schema, originalAbi: JSON.stringify(abi) };
+        const contractName = metadata.contractName || `Contract_${address.substring(0, 6)}`;
+        const schema = transformAbiToSchema(abi, contractName, address);
+        return { schema, originalAbi: JSON.stringify(abi) };
+      } catch (inner) {
+        lastError = inner as Error;
+        continue;
+      }
+    }
+    throw lastError ?? new Error('Sourcify metadata not found for any candidate URL');
   } catch (error) {
     logger.warn('loadAbiFromSourcify', `Failed to fetch ABI from Sourcify: ${String(error)}`);
     throw error as Error;

--- a/packages/builder/docs/deeplinks.md
+++ b/packages/builder/docs/deeplinks.md
@@ -83,6 +83,18 @@ Edge cases (for testing)
 ?ecosystem=evm&networkId=ethereum-sepolia&networkId=ethereum-sepolia&address=0x753E2CFc06cF3bD485B846238828a9DA543BFF41
 ```
 
+### Provider notes: Sourcify (EVM)
+
+- **Match types**: Sourcify’s repo host expects explicit match types. We fetch metadata from:
+  - `contracts/full_match/<chainId>/<address>/metadata.json`
+  - `contracts/partial_match/<chainId>/<address>/metadata.json`
+    The `any` match type is not supported on the repo host and will return a validation error (`request/params/matchType must match format "match-type"`).
+- **Address casing**: Addresses are stored in lowercase on disk; the builder tries lowercase and original-casing for robustness.
+- **Forced provider semantics**: If you deep link with `service=sourcify` and both `full_match` and `partial_match` miss, the load fails without falling back to other providers (by design).
+- **Examples**:
+  - Viewer page (human‑readable): [Sourcify contract viewer (USDT)](https://repo.sourcify.dev/1/0xdAC17F958D2ee523a2206206994597C13D831ec7)
+  - Direct metadata (lowercase address): `https://repo.sourcify.dev/contracts/full_match/1/0xdac17f958d2ee523a2206206994597c13d831ec7/metadata.json`
+
 ### Tips
 
 - If you need to test UI default vs. forced provider precedence, first set your default provider in `Network Settings → Contract Definitions`, then use a deep link with `service=...` to override it temporarily.


### PR DESCRIPTION
### Sourcify integration: robust fetch + docs

- Fix(adapter-evm): Handle Sourcify repo paths more robustly by trying `contracts/full_match/<chainId>/<address>/metadata.json` then `contracts/partial_match/...`. Also try lowercase and original-casing addresses to match on-disk layout.
- Docs(builder): Add “Provider notes: Sourcify (EVM)” to deeplinks guide documenting match-type behavior, casing, and forced-provider semantics.

Behavioral notes
- Forced provider via `service=sourcify` continues to fail-fast without cross-provider fallback (unchanged).
- Removes unsupported `any` match type usage to avoid OpenAPI validation errors.

References
- Sourcify viewer (USDT): https://repo.sourcify.dev/1/0xdAC17F958D2ee523a2206206994597C13D831ec7
- Direct metadata example: https://repo.sourcify.dev/contracts/full_match/1/0xdac17f958d2ee523a2206206994597c13d831ec7/metadata.json

QA
- Verified deep-link with `?ecosystem=evm&chainId=1&address=0xdAC17F...&service=sourcify` loads successfully when present in Sourcify and fails fast when not.
- Lint, adapter compliance, and snapshot checks pass.
