### PR TITLE
docs: Stellar adapter READMEs + main README ToC and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,88 @@
 
 > Spin up a front-end for any contract call in seconds. Select the function, auto-generate a React UI with wallet connect and multi-network support, and export a complete app.
 
+## Project Status
+
+This project is currently in development.
+
+[![CI](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/ci.yml)
+[![Coverage](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/coverage.yml/badge.svg)](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/coverage.yml)
+[![codecov](https://codecov.io/gh/OpenZeppelin/contracts-ui-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenZeppelin/contracts-ui-builder)
+[![Publish](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/publish.yml/badge.svg)](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/publish.yml)
+[![Dependencies](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/dependencies.yml/badge.svg)](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/dependencies.yml)
+[![Dependency Review](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/dependency-review.yml)
+[![Update Dependencies](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/update-dependencies.yml/badge.svg)](https://github.com/OpenZeppelin/contracts-ui-builder/actions/workflows/update-dependencies.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/OpenZeppelin/contracts-ui-builder/badge)](https://api.securityscorecards.dev/projects/github.com/OpenZeppelin/contracts-ui-builder)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-brightgreen.svg)](https://conventionalcommits.org)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![Storybook](https://img.shields.io/badge/Storybook-FF4785?logo=storybook&logoColor=white)](https://storybook.js.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![React](https://img.shields.io/badge/React-20232A?logo=react&logoColor=61DAFB)](https://reactjs.org/)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?logo=tailwind-css&logoColor=white)](https://tailwindcss.com/)
+[![Vite](https://img.shields.io/badge/Vite-B73BFE?logo=vite&logoColor=FFD62E)](https://vitejs.dev/)
+[![pnpm](https://img.shields.io/badge/pnpm-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+[![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/OpenZeppelin/contracts-ui-builder/maintainability)
+
+## Table of Contents
+
+- [Monorepo Structure](#monorepo-structure)
+- [Packages](#packages)
+  - [Builder Package](#builder-package)
+  - [React Core Package](#react-core-package)
+  - [Renderer Package](#renderer-package)
+  - [UI Package](#ui-package)
+  - [Utils Package](#utils-package)
+  - [Types Package](#types-package)
+  - [Styles Package](#styles-package)
+  - [Storage Package](#storage-package)
+  - [EVM Adapter](#evm-adapter)
+  - [Solana Adapter](#solana-adapter)
+  - [Stellar Adapter](#stellar-adapter)
+  - [Midnight Adapter](#midnight-adapter)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Running with Docker (Recommended)](#running-with-docker-recommended)
+- [Available Scripts](#available-scripts)
+- [Project Structure](#project-structure)
+  - [Core Packages](#core-packages)
+  - [Adapter Packages](#adapter-packages)
+  - [Configuration Structure](#configuration-structure)
+- [Architecture](#architecture)
+- [Project Constitution](#project-constitution)
+- [Build System](#build-system)
+  - [Adapter Pattern Enforcement](#adapter-pattern-enforcement)
+- [Component Architecture](#component-architecture)
+  - [Renderer Components](#renderer-components)
+  - [Storybook Integration](#storybook-integration)
+- [Code Style](#code-style)
+  - [Git Hooks](#git-hooks)
+  - [CSS Class Name Sorting](#css-class-name-sorting)
+  - [Shared Prettier Configuration](#shared-prettier-configuration)
+  - [Import Sorting](#import-sorting)
+- [Dependency Management](#dependency-management)
+  - [Exported Package Versions](#exported-package-versions)
+  - [Checking for Outdated Dependencies](#checking-for-outdated-dependencies)
+  - [Updating Dependencies](#updating-dependencies)
+  - [Automated Updates](#automated-updates)
+- [Adding New Adapters](#adding-new-adapters)
+- [Commit Convention](#commit-convention)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
+- [CI/CD Pipeline](#cicd-pipeline)
+  - [Package Publishing](#package-publishing)
+- [Monorepo Configuration](#monorepo-configuration)
+  - [Shared Configurations](#shared-configurations)
+- [Runtime Configuration](#runtime-configuration)
+  - [Builder Application Configuration (Development)](#builder-application-configuration-development)
+  - [Exported Application Configuration](#exported-application-configuration)
+
 ## Status
 
 This project is currently in development.
@@ -46,6 +128,20 @@ This project is organized as a monorepo with the following packages:
 
 ## Packages
 
+### Builder Package
+
+The main application with the builder UI, export system, and core logic.
+
+For more details, see the [Builder README](./packages/builder/README.md).
+
+### React Core Package
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-react-core.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-react-core)
+
+Core React providers and hooks (AdapterProvider, WalletStateProvider, useWalletState) for managing adapter and wallet state.
+
+For more details, see the [React Core README](./packages/react-core/README.md).
+
 ### Renderer Package
 
 [![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-renderer.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-renderer)
@@ -64,6 +160,8 @@ For more details, see the [Renderer README](./packages/renderer/README.md).
 
 ### Types Package
 
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-types.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-types)
+
 The `types` package contains shared TypeScript type definitions for all packages in the ecosystem. It serves as the single source of truth for types used across the Contracts UI Builder.
 
 Features:
@@ -76,6 +174,8 @@ Features:
 For more details, see the [Types README](./packages/types/README.md).
 
 ### Styles Package
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-styles.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-styles)
 
 The `styles` package contains the centralized styling system used across all packages. It provides consistent theming, spacing, and component styles throughout the application.
 
@@ -90,6 +190,8 @@ For more details, see the [Styles README](./packages/styles/README.md).
 
 ### Storage Package
 
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-storage.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-storage)
+
 The `storage` package provides local storage services built on IndexedDB using Dexie.js for persisting contract UI configurations. It enables a complete history and auto-save system for the builder application.
 
 Features:
@@ -103,6 +205,62 @@ Features:
 - Integration with React hooks for seamless UI state management
 
 For more details, see the [Storage README](./packages/storage/README.md).
+
+### UI Package
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-ui.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-ui)
+
+Shared UI primitives and form field components for a consistent UX across builder and renderer.
+
+For more details, see the [UI README](./packages/ui/README.md).
+
+### Utils Package
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-utils.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-utils)
+
+Framework-agnostic utilities like logging, runtime configuration, validation, and helpers.
+
+For more details, see the [Utils README](./packages/utils/README.md).
+
+### EVM Adapter
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-adapter-evm.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-adapter-evm)
+
+_Status: Fully implemented._
+
+Adapter implementation for EVM-compatible chains.
+
+For more details, see the [EVM Adapter README](./packages/adapter-evm/README.md).
+
+### Solana Adapter
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-adapter-solana.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-adapter-solana)
+
+_Status: Scaffolding._
+
+Adapter implementation for Solana.
+
+For more details, see the [Solana Adapter README](./packages/adapter-solana/README.md).
+
+### Stellar Adapter
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-adapter-stellar.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-adapter-stellar)
+
+_Status: Fully Implemented._
+
+Adapter implementation for Stellar (Soroban).
+
+For more details, see the [Stellar Adapter README](./packages/adapter-stellar/README.md).
+
+### Midnight Adapter
+
+[![npm version](https://img.shields.io/npm/v/@openzeppelin/contracts-ui-builder-adapter-midnight.svg)](https://www.npmjs.com/package/@openzeppelin/contracts-ui-builder-adapter-midnight)
+
+_Status: In progress._
+
+Adapter implementation for Midnight.
+
+For more details, see the [Midnight Adapter README](./packages/adapter-midnight/README.md).
 
 ## Features
 
@@ -173,13 +331,15 @@ For more details, see the [Storage README](./packages/storage/README.md).
 
 For a consistent and reliable development environment, it is highly recommended to run the application using Docker. This avoids potential issues with local Node.js, pnpm, or operating system configurations.
 
-1.  **Prerequisites**: Make sure you have Docker and Docker Compose installed on your system.
+1. **Prerequisites**: Make sure you have Docker and Docker Compose installed on your system.
 
-2.  **Build and Run the Container**:
-    ```bash
-    docker-compose up --build
-    ```
-    This command will build the Docker image and start the application. Once it's running, you can access it at `http://localhost:3000`.
+2. **Build and Run the Container**:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+   This command will build the Docker image and start the application. Once it's running, you can access it at `http://localhost:3000`.
 
 ## Available Scripts
 
@@ -233,7 +393,7 @@ This monorepo is organized into several specialized packages, each with a specif
 
 ### Configuration Structure
 
-```
+```text
 contracts-ui-builder/
 ├── .github/             # GitHub workflows and templates
 ├── .storybook/          # Storybook configuration
@@ -458,37 +618,37 @@ The project is configured with:
 
 To add support for a new blockchain ecosystem:
 
-1.  **Create Package**: Create a new directory `packages/adapter-<chain-name>` (e.g., `packages/adapter-sui`).
-2.  **Define `package.json`**:
-    - Set the package name (e.g., `@openzeppelin/contracts-ui-builder-adapter-sui`).
-    - Add a dependency on `@openzeppelin/contracts-ui-builder-types` (`workspace:*`).
-    - Add any chain-specific SDKs or libraries required by the adapter.
-    - Include standard build scripts (refer to existing adapter packages).
-    - **Important**: Ensure your package exports a named array of its `NetworkConfig[]` objects (e.g., `export const suiNetworks = [...]`) and its main `Adapter` class from its entry point (`src/index.ts`).
-3.  **Define `tsconfig.json`**: Create a `tsconfig.json` extending the root `tsconfig.base.json`.
-4.  **Implement Adapter**:
-    - Create `src/adapter.ts`.
-    - Import `ContractAdapter`, the specific `YourEcosystemNetworkConfig` (e.g., `SuiNetworkConfig`), and related types from `@openzeppelin/contracts-ui-builder-types`.
-    - Implement the `ContractAdapter` interface. The constructor **must** accept its specific `NetworkConfig` (e.g., `constructor(networkConfig: SuiNetworkConfig)`).
-    - Implement methods to use `this.networkConfig` internally for network-specific operations (e.g., initializing HTTP clients with RPC URLs from the config).
-5.  **Define Network Configurations**:\
-    - Create `src/networks/mainnet.ts`, `testnet.ts`, etc., defining `YourEcosystemNetworkConfig` objects for each supported network.
-    - Each network config must provide all necessary details for the adapter to function, such as RPC endpoints (`rpcUrl` or `rpcEndpoint`), chain identifiers (`chainId` for EVM), explorer URLs, native currency details, etc., as defined by its `YourEcosystemNetworkConfig` interface.
-    - Create `src/networks/index.ts` to export the combined list of networks (e.g., `export const suiNetworks = [...mainnetSuiNetworks, ...testnetSuiNetworks];`) and also export each network configuration individually by its constant name (e.g., `export { suiMainnet, suiTestnet } from './mainnet';`).
-6.  **Export Adapter & Networks**: Create `src/index.ts` in your adapter package and export the adapter class (e.g., `export { SuiAdapter } from './adapter';`) and the main networks array (e.g., `export { suiNetworks } from './networks';`). It's also good practice to re-export individual network configurations from the adapter's main entry point if they might be directly imported by consumers.
-7.  **Register Ecosystem in Builder**:
-    - Open `packages/builder/src/core/ecosystemManager.ts`.
-    - Import the new adapter class (e.g., `import { SuiAdapter } from '@openzeppelin/contracts-ui-builder-adapter-sui';`).
-    - Add a new entry to the `ecosystemRegistry` object. This entry defines:
-      - `networksExportName`: The string name of the exported network list (e.g., 'suiNetworks'). This is used by the `EcosystemManager` to dynamically load all network configurations for an ecosystem.
-      - `AdapterClass`: The constructor of your adapter (e.g., `SuiAdapter as AnyAdapterConstructor`).
-    - Add a case for your new ecosystem in the `switch` statement within `loadAdapterPackageModule` to enable dynamic import of your adapter package module (which should export the `AdapterClass` and the `networksExportName` list).
-    - Note: If the adapter requires specific package dependencies for _exported projects_ (beyond its own runtime dependencies), these are typically managed by the `PackageManager` configuration within the adapter package itself (e.g., an `adapter.config.ts` file exporting dependency details).
-8.  **Workspace**: Ensure the new package is included in the `pnpm-workspace.yaml` (if not covered by `packages/*`).
-9.  **Build & Test**:
-    - Build the new adapter package (`pnpm --filter @openzeppelin/contracts-ui-builder-adapter-<chain-name> build`).
-    - Add relevant unit/integration tests.
-    - Ensure the builder application (`pnpm --filter @openzeppelin/contracts-ui-builder-app build`) and the export system still function correctly.
+1. **Create Package**: Create a new directory `packages/adapter-<chain-name>` (e.g., `packages/adapter-sui`).
+2. **Define `package.json`**:
+   - Set the package name (e.g., `@openzeppelin/contracts-ui-builder-adapter-sui`).
+   - Add a dependency on `@openzeppelin/contracts-ui-builder-types` (`workspace:*`).
+   - Add any chain-specific SDKs or libraries required by the adapter.
+   - Include standard build scripts (refer to existing adapter packages).
+   - **Important**: Ensure your package exports a named array of its `NetworkConfig[]` objects (e.g., `export const suiNetworks = [...]`) and its main `Adapter` class from its entry point (`src/index.ts`).
+3. **Define `tsconfig.json`**: Create a `tsconfig.json` extending the root `tsconfig.base.json`.
+4. **Implement Adapter**:
+   - Create `src/adapter.ts`.
+   - Import `ContractAdapter`, the specific `YourEcosystemNetworkConfig` (e.g., `SuiNetworkConfig`), and related types from `@openzeppelin/contracts-ui-builder-types`.
+   - Implement the `ContractAdapter` interface. The constructor **must** accept its specific `NetworkConfig` (e.g., `constructor(networkConfig: SuiNetworkConfig)`).
+   - Implement methods to use `this.networkConfig` internally for network-specific operations (e.g., initializing HTTP clients with RPC URLs from the config).
+5. **Define Network Configurations**:\
+   - Create `src/networks/mainnet.ts`, `testnet.ts`, etc., defining `YourEcosystemNetworkConfig` objects for each supported network.
+   - Each network config must provide all necessary details for the adapter to function, such as RPC endpoints (`rpcUrl` or `rpcEndpoint`), chain identifiers (`chainId` for EVM), explorer URLs, native currency details, etc., as defined by its `YourEcosystemNetworkConfig` interface.
+   - Create `src/networks/index.ts` to export the combined list of networks (e.g., `export const suiNetworks = [...mainnetSuiNetworks, ...testnetSuiNetworks];`) and also export each network configuration individually by its constant name (e.g., `export { suiMainnet, suiTestnet } from './mainnet';`).
+6. **Export Adapter & Networks**: Create `src/index.ts` in your adapter package and export the adapter class (e.g., `export { SuiAdapter } from './adapter';`) and the main networks array (e.g., `export { suiNetworks } from './networks';`). It's also good practice to re-export individual network configurations from the adapter's main entry point if they might be directly imported by consumers.
+7. **Register Ecosystem in Builder**:
+   - Open `packages/builder/src/core/ecosystemManager.ts`.
+   - Import the new adapter class (e.g., `import { SuiAdapter } from '@openzeppelin/contracts-ui-builder-adapter-sui';`).
+   - Add a new entry to the `ecosystemRegistry` object. This entry defines:
+     - `networksExportName`: The string name of the exported network list (e.g., 'suiNetworks'). This is used by the `EcosystemManager` to dynamically load all network configurations for an ecosystem.
+     - `AdapterClass`: The constructor of your adapter (e.g., `SuiAdapter as AnyAdapterConstructor`).
+   - Add a case for your new ecosystem in the `switch` statement within `loadAdapterPackageModule` to enable dynamic import of your adapter package module (which should export the `AdapterClass` and the `networksExportName` list).
+   - Note: If the adapter requires specific package dependencies for _exported projects_ (beyond its own runtime dependencies), these are typically managed by the `PackageManager` configuration within the adapter package itself (e.g., an `adapter.config.ts` file exporting dependency details).
+8. **Workspace**: Ensure the new package is included in the `pnpm-workspace.yaml` (if not covered by `packages/*`).
+9. **Build & Test**:
+   - Build the new adapter package (`pnpm --filter @openzeppelin/contracts-ui-builder-adapter-<chain-name> build`).
+   - Add relevant unit/integration tests.
+   - Ensure the builder application (`pnpm --filter @openzeppelin/contracts-ui-builder-app build`) and the export system still function correctly.
 
 ## Commit Convention
 
@@ -497,7 +657,7 @@ more details.
 
 Example:
 
-```
+```text
 feat(ui): add button component
 ```
 
@@ -597,38 +757,4 @@ The structure of this JSON file includes sections for:
 
 Refer to the README included with the exported application for detailed instructions on configuring `public/app.config.json`.
 
-### Adding/Modifying Networks
-
-When adding new EVM network definitions (in `packages/adapter-evm/src/networks/`), ensure you define:
-
-- `id`: A unique string identifier (e.g., "my-custom-chain-mainnet").
-- `chainId`: The numeric EVM chain ID.
-- `rpcUrl`: A default public RPC URL.
-- `primaryExplorerApiIdentifier`: A string (e.g., "mychainscan-mainnet") that will be used as the key in `app.config.json`'s `networkServiceConfigs` if this network's explorer requires an API key for ABI fetching.
-- `apiUrl` and `explorerUrl` for the block explorer.
-
-If this network is also to be a chain-switchable target within Wagmi (for the EVM adapter), you may need to update the `defaultSupportedChains` array and the `viemChainIdToAppNetworkIdMap` in `packages/adapter-evm/src/wallet/wagmi-implementation.ts` to ensure RPC overrides from `app.config.json` apply correctly to Wagmi's transports for this chain.
-
-### Midnight Wallet Integration
-
-The `@openzeppelin/contracts-ui-builder-adapter-midnight` package handles integration with the Midnight ecosystem, specifically the Lace wallet. Integrating with the Midnight wallet requires special handling due to its unique, non-blocking connection flow, which differs from many other wallet APIs.
-
-Key characteristics of the Midnight wallet integration:
-
-- **Non-Blocking `enable()`**: The wallet's `enable()` method resolves immediately, returning a "pre-flight" API object before the user has granted or denied connection permissions.
-- **State Polling**: To manage this, the adapter implements a state-polling mechanism. After `enable()` is called, the adapter repeatedly checks the wallet's state until the user approves the connection.
-- **Explicit Disconnect Handling**: The wallet's API does not provide a programmatic `disconnect` function. The adapter simulates disconnection by setting a flag in `localStorage` to prevent automatic reconnection in subsequent sessions, respecting the user's intent to disconnect.
-
-This implementation ensures a robust and user-friendly connection experience despite the underlying API's unconventional behavior. For a detailed look at the implementation, see the `MidnightWalletProvider.tsx` component within the adapter package.
-
-### Advanced EVM Wallet Integration & UI Customization
-
-The `@openzeppelin/contracts-ui-builder-adapter-evm` package offers robust integration with EVM wallets, leveraging the `wagmi` library. It features an enhanced architecture for UI kit integration, providing:
-
-- **Stable UI Rendering**: A new internal architecture (`EvmUiKitManager` and `EvmWalletUiRoot`) significantly reduces UI flickering during network switches when using supported UI kits.
-- **Support for UI Kits (e.g., RainbowKit)**: Easily integrate popular Wagmi-based UI kits like RainbowKit.
-- **Flexible Configuration**: Configure your chosen UI kit through a layered system involving global application settings (via `app.config.json` or environment variables), detailed kit-specific parameters in user-authored native TypeScript configuration files (e.g., `src/config/wallet/rainbowkit.config.ts`), and programmatic overrides.
-- **Automatic Asset Loading**: For supported kits like RainbowKit, necessary CSS and JavaScript assets are loaded dynamically by the adapter.
-- **Custom UI Option**: Retains support for a default set of custom-styled wallet components if no third-party kit is preferred.
-
-**For comprehensive details on configuring the EVM adapter's wallet module, setting up UI kits like RainbowKit, understanding the configuration flow, and the pattern for extending support to other UI kits, please refer to the dedicated [EVM Adapter Wallet Module README](./packages/adapter-evm/src/wallet/README.md).**
+<!-- Adapter-specific guides are documented in their respective package READMEs. -->

--- a/packages/adapter-evm/src/wallet/README.md
+++ b/packages/adapter-evm/src/wallet/README.md
@@ -19,7 +19,7 @@ This architecture allows applications to switch between different wallet UIs (li
 
 ## Directory Structure
 
-```
+```text
 wallet/
 ├── components/         # Core UI root (`EvmWalletUiRoot`) and custom wallet UI components
 │   ├── EvmWalletUiRoot.tsx
@@ -198,10 +198,10 @@ Applications can also call `adapter.configureUiKit(programmaticUiKitConfig, { lo
 
 ### Configuration Precedence
 
-1.  **Programmatic Overrides**: Settings passed directly to `configureUiKit` (for `kitName` or other top-level `UiKitConfiguration` flags, and `kitConfig` properties).
-2.  **User-Native `.ts` File**: Content from files like `src/config/wallet/rainbowkit.config.ts` (for `kitConfig` properties).
-3.  **`AppConfigService` (`app.config.json` / Env Vars)**: Baseline settings (for `kitName` and `kitConfig` properties).
-4.  **Adapter Defaults**: Internal defaults (e.g., `kitName: 'custom'`).
+1. **Programmatic Overrides**: Settings passed directly to `configureUiKit` (for `kitName` or other top-level `UiKitConfiguration` flags, and `kitConfig` properties).
+2. **User-Native `.ts` File**: Content from files like `src/config/wallet/rainbowkit.config.ts` (for `kitConfig` properties).
+3. **`AppConfigService` (`app.config.json` / Env Vars)**: Baseline settings (for `kitName` and `kitConfig` properties).
+4. **Adapter Defaults**: Internal defaults (e.g., `kitName: 'custom'`).
 
 ## Automatic CSS Loading (RainbowKit)
 
@@ -215,7 +215,7 @@ The primary way to interact with wallet functionalities and UI components is thr
 - **`useWalletState()`**: Hook to access `activeAdapter`, `activeNetworkConfig`, `walletFacadeHooks`, `isAdapterLoading`, etc.
 - **Derived Hooks** (e.g., `useDerivedAccountStatus`, `useDerivedConnectStatus`): Provide convenient, memoized state from facade hooks.
 
-**Example: Rendering Wallet UI in a Header**
+### Example: Rendering Wallet UI in a Header
 
 ```typescript
 import {

--- a/packages/adapter-stellar/README.md
+++ b/packages/adapter-stellar/README.md
@@ -1,65 +1,80 @@
 # Stellar Adapter (`@openzeppelin/contracts-ui-builder-adapter-stellar`)
 
-This package provides the `ContractAdapter` implementation for the Stellar network for the Contracts UI Builder.
+This package provides the `ContractAdapter` implementation for the Stellar (Soroban) ecosystem for the Contracts UI Builder.
 
-**Note:** While the basic structure is in place, including network configuration definitions, the core adapter logic for Stellar-specific operations is currently a placeholder and will be implemented in future development phases.
-
-It is intended to be responsible for:
+It is responsible for:
 
 - Implementing the `ContractAdapter` interface from `@openzeppelin/contracts-ui-builder-types`.
-- Defining and exporting specific Stellar network configurations (e.g., Public Network, Testnet) as `StellarNetworkConfig` objects. These are located in `src/networks/` and include details like Horizon URLs, network passphrases, and explorer URLs.
-- Loading Stellar contract metadata (e.g., from XDR for Soroban contracts).
-- Mapping Stellar-specific data types (e.g., Soroban types) to the form field types.
-- Parsing user input into Stellar operations/transactions, according to the `StellarNetworkConfig`.
-- Formatting results from Horizon API queries or contract state.
-- Interacting with Stellar wallets (e.g., via Freighter, Albedo) for signing and submitting transactions on the configured network.
-- Providing other Stellar-specific configurations and validation.
+- Defining and exporting Stellar network configurations (Public Network and Testnet) as `StellarNetworkConfig` objects in `src/networks/` (Horizon URL, Soroban RPC URL, network passphrase, explorer URL, icon, etc.).
+- Loading Stellar contract definitions and metadata and transforming them into the builder’s chain‑agnostic `ContractSchema`.
+- Mapping Soroban value types to builder form fields and validating user input.
+- Parsing user inputs into Soroban `ScVal` types for transaction execution and formatting view results.
+- Transaction execution using an execution strategy pattern (EOA and Relayer strategies).
+- Wallet integration and UI via the `src/wallet/` module.
+- Adapter‑specific configuration and validation helpers (RPC resolution, explorer URLs, execution configuration validation).
 
-## Usage
+---
 
-Once fully implemented, the `StellarAdapter` class will be instantiated with a specific `StellarNetworkConfig` object:
+## Transaction Execution
 
-```typescript
-// Example: import { stellarPubnet } from '@openzeppelin/contracts-ui-builder-adapter-stellar';
-import { StellarAdapter } from '@openzeppelin/contracts-ui-builder-adapter-stellar';
-import { StellarNetworkConfig } from '@openzeppelin/contracts-ui-builder-types';
+The Stellar adapter uses an execution strategy pattern similar to the EVM adapter to handle transaction submissions.
 
-// For type access if needed
+### Supported Strategies
 
-// Placeholder: Actual network config objects would be imported from './networks'
-const placeholderNetworkConfig: StellarNetworkConfig = {
-  id: 'stellar-testnet',
-  name: 'Stellar Testnet',
-  ecosystem: 'stellar',
-  network: 'stellar',
-  type: 'testnet',
-  isTestnet: true,
-  horizonUrl: 'https://horizon-testnet.stellar.org',
-  networkPassphrase: 'Test SDF Network ; September 2015',
-  explorerUrl: 'https://stellar.expert/explorer/testnet',
-  // ... any other StellarNetworkConfig fields
-};
+1. EOA (Externally Owned Account): Uses the connected Stellar wallet (via Stellar Wallets Kit) to sign and submit Soroban transactions directly.
+2. Relayer: Uses the OpenZeppelin Relayer service to submit transactions. The adapter exposes a `StellarRelayerOptions` React component to configure strategy‑specific options in the Builder UI.
 
-const stellarAdapter = new StellarAdapter(placeholderNetworkConfig);
+The adapter selects the strategy at runtime based on the `ExecutionConfig` provided by the application.
 
-// Use stellarAdapter for operations on the configured Stellar network
-```
+### Configuration in the Builder
 
-Network configurations for Stellar networks (e.g., `stellarPubnet`, `stellarTestnet`) are defined and exported from `src/networks/index.ts` within this package. The full list is exported as `stellarNetworks`.
+The Builder application’s “Customize” step passes an `ExecutionConfig` to the adapter’s `signAndBroadcast` method. The adapter uses a factory to instantiate the appropriate strategy and reports live status updates via the provided `onStatusChange` callback.
+
+---
+
+## Wallet Integration & UI
+
+All wallet integration logic, UI components, facade hooks, and the UI context provider for Stellar are located in `src/wallet/`.
+
+The `StellarAdapter` implements the optional UI methods from `ContractAdapter`:
+
+- `getEcosystemReactUiContextProvider()` returns `StellarWalletUiRoot`, a stable provider root for Stellar wallet state.
+- `getEcosystemReactHooks()` returns `stellarFacadeHooks` for account and connection status.
+- `getEcosystemWalletComponents()` returns available wallet UI components (e.g., `ConnectButton`, `AccountDisplay`) for the active UI kit.
+
+For full documentation on the wallet module, see `src/wallet/README.md`.
+
+---
+
+This adapter follows the standard module structure outlined in the main project Adapter Architecture Guide.
 
 ## Package Structure
 
 ```text
 adapter-stellar/
 ├── src/
-│   ├── config/                  # Adapter-specific configuration
-│   ├── contract/                # Contract interaction utilities
-│   ├── mapping/                 # Type mapping utilities
+│   ├── configuration/           # Adapter-specific configuration (RPC, explorer, execution)
+│   ├── contract/                # Contract loading & metadata
+│   ├── mapping/                 # Soroban ↔ form field mapping & generators
 │   ├── networks/                # Stellar network configurations
-│   ├── operations/              # Stellar operations management
-│   ├── transaction/             # Transaction execution system
-│   ├── validation/              # Validation utilities
-│   ├── wallet/                  # Wallet integration (placeholder)
+│   ├── query/                   # View function execution
+│   ├── transaction/             # Transaction execution system (EOA, Relayer)
+│   │   ├── components/                # React components for configuration
+│   │   ├── formatter.ts               # Build Soroban tx data from form inputs
+│   │   ├── execution-strategy.ts      # Strategy interface
+│   │   ├── eoa.ts / relayer.ts        # Strategy implementations
+│   ├── transform/               # Input parsing and output formatting
+│   ├── types/                   # Adapter-specific types
+│   ├── utils/                   # Utilities (artifact handling, formatting, etc.)
+│   ├── validation/              # Validation utilities (addresses, configs)
+│   ├── wallet/                  # Wallet integration (see wallet/README.md)
+│   │   ├── components/                # Wallet UI components
+│   │   ├── context/                   # Wallet context
+│   │   ├── hooks/                     # Facade & low-level hooks
+│   │   ├── implementation/            # Stellar Wallets Kit implementation
+│   │   ├── services/                  # Config resolution for wallet UI
+│   │   ├── stellar-wallets-kit/       # Kit-specific helpers
+│   │   ├── README.md                  # Detailed wallet documentation
 │   ├── adapter.ts               # Main StellarAdapter class implementation
 │   └── index.ts                 # Public package exports
 ├── package.json
@@ -69,6 +84,78 @@ adapter-stellar/
 └── README.md
 ```
 
-## Internal Structure
+---
 
-This adapter follows the standard module structure outlined in the main project [Adapter Architecture Guide](../../docs/ADAPTER_ARCHITECTURE.md), with the `src/networks/` directory for managing its network configurations.
+## Usage (Adapter Instantiation)
+
+Instantiate the adapter with a specific `StellarNetworkConfig`:
+
+```typescript
+import { StellarAdapter, stellarTestnet } from '@openzeppelin/contracts-ui-builder-adapter-stellar';
+
+const networkConfig = stellarTestnet; // or stellarPublic
+const stellarAdapter = new StellarAdapter(networkConfig);
+
+// Use stellarAdapter for operations on the configured Stellar network
+```
+
+Network configurations for Stellar networks are exported from `src/networks/index.ts` (`stellarPublic`, `stellarTestnet`, arrays `stellarMainnetNetworks`, `stellarTestnetNetworks`, and `stellarNetworks`).
+
+## Soroban RPC URL Configuration
+
+Each `StellarNetworkConfig` specifies a default `sorobanRpcUrl`.
+
+This URL can be overridden at runtime by the consuming application through the central `AppConfigService`. Configuration is loaded from environment variables (for the Builder app) or a `public/app.config.json` file (for exported apps).
+
+To override a RPC URL, define an entry in `rpcEndpoints` keyed by the network’s string ID (e.g., `"stellar-testnet"`).
+
+In `.env` for the Builder app:
+`VITE_APP_CFG_RPC_ENDPOINT_STELLAR_TESTNET="https://your-custom-soroban-rpc.testnet.example"`
+
+In `public/app.config.json` for an exported app:
+
+```json
+{
+  "rpcEndpoints": {
+    "stellar-testnet": "https://your-custom-soroban-rpc.testnet.example",
+    "stellar-public": "https://your-custom-soroban-rpc.public.example"
+  }
+}
+```
+
+The adapter resolves Soroban RPC in this order:
+
+1. User-provided RPC config from `UserRpcConfigService` (advanced user input)
+2. RPC override via `AppConfigService.getRpcEndpointOverride(networkId)`
+3. Default `sorobanRpcUrl` from the active `StellarNetworkConfig`
+
+## Explorer URLs
+
+Stellar explorers are used for display only. The adapter constructs URLs using `explorerUrl` from the network config:
+
+- `getExplorerUrl(address)` → `.../account/{address}` or `.../contract/{id}` (Soroban contracts)
+- `getExplorerTxUrl(txHash)` → `.../tx/{hash}`
+
+No explorer API keys are required for adapter functionality.
+
+## Network Configurations
+
+Stellar networks are exported from `src/networks/`. Each `StellarNetworkConfig` includes:
+
+- `id`: Unique network identifier (e.g., `"stellar-public"`, `"stellar-testnet"`)
+- `name`: Display name
+- `ecosystem`: Always `"stellar"`
+- `network`: Always `"stellar"`
+- `type`: `"mainnet"` or `"testnet"`
+- `isTestnet`: boolean
+- `horizonUrl`: Horizon endpoint for the network
+- `sorobanRpcUrl`: Soroban JSON-RPC endpoint
+- `networkPassphrase`: The network passphrase used by Wallets Kit / SDK
+- `explorerUrl`: Base URL for the explorer (display only)
+- `icon`: Icon identifier
+
+See `src/networks/README.md` for details on adding networks and overriding RPC.
+
+---
+
+This adapter generally follows the standard module structure and developer experience provided by the EVM adapter, while keeping the core app chain‑agnostic.

--- a/packages/adapter-stellar/src/networks/README.md
+++ b/packages/adapter-stellar/src/networks/README.md
@@ -1,0 +1,84 @@
+# Stellar Adapter Networks
+
+This directory defines the Stellar network configurations exported by the adapter.
+
+## Available Networks
+
+Exports from `index.ts`:
+
+- `stellarPublic` (mainnet)
+- `stellarTestnet` (testnet)
+- `stellarMainnetNetworks`: `StellarNetworkConfig[]` containing all mainnet networks
+- `stellarTestnetNetworks`: `StellarNetworkConfig[]` containing all testnet networks
+- `stellarNetworks`: union of all supported networks
+
+Each `StellarNetworkConfig` includes:
+
+- `id`: Unique identifier (e.g., `"stellar-public"`, `"stellar-testnet"`)
+- `name`: Display name
+- `ecosystem`: `"stellar"`
+- `network`: `"stellar"`
+- `type`: `"mainnet" | "testnet"`
+- `isTestnet`: boolean
+- `horizonUrl`: Horizon REST URL
+- `sorobanRpcUrl`: Soroban JSON-RPC URL
+- `networkPassphrase`: Network passphrase
+- `explorerUrl`: Base explorer URL (for display links)
+- `icon`: Icon identifier
+
+## Soroban RPC URL Overrides
+
+You can override the default `sorobanRpcUrl` at runtime through `AppConfigService`.
+
+In `.env` (Builder app):
+`VITE_APP_CFG_RPC_ENDPOINT_STELLAR_TESTNET="https://your-custom-soroban-rpc.testnet.example"`
+
+In `public/app.config.json` (exported apps):
+
+```json
+{
+  "rpcEndpoints": {
+    "stellar-testnet": "https://your-custom-soroban-rpc.testnet.example",
+    "stellar-public": "https://your-custom-soroban-rpc.public.example"
+  }
+}
+```
+
+Resolution order used by the adapter:
+
+1. User RPC from `UserRpcConfigService`
+2. `AppConfigService.getRpcEndpointOverride(networkId)`
+3. Default `sorobanRpcUrl` from the network config
+
+## Adding a New Stellar Network
+
+1. Add the network to `mainnet.ts` or `testnet.ts`:
+
+```typescript
+export const stellarCustom: StellarNetworkConfig = {
+  id: 'stellar-custom',
+  exportConstName: 'stellarCustom',
+  name: 'Stellar Custom',
+  ecosystem: 'stellar',
+  network: 'stellar',
+  type: 'testnet',
+  isTestnet: true,
+  horizonUrl: 'https://horizon.custom.example',
+  sorobanRpcUrl: 'https://soroban.custom.example',
+  networkPassphrase: 'Custom Network Passphrase',
+  explorerUrl: 'https://stellar.expert/explorer/custom',
+  icon: 'stellar',
+};
+```
+
+1. Include it in the appropriate array and export it from `index.ts`.
+2. Re-export from the package root in `src/index.ts` if you want it available to consumers.
+
+## Explorer URLs
+
+Explorers are used for display only. The adapter builds links using `explorerUrl`:
+
+- Address or contract: `.../account/{address}` or `.../contract/{id}`
+- Transaction: `.../tx/{hash}`
+
+No explorer API keys are required for Stellar adapter functionality.

--- a/packages/adapter-stellar/src/wallet/README.md
+++ b/packages/adapter-stellar/src/wallet/README.md
@@ -1,97 +1,62 @@
 # Stellar Adapter Wallet Module
 
-This directory contains the wallet integration layer for the Stellar adapter, providing all wallet-related UI, hooks, context, and utilities for Stellar blockchain using the `@creit.tech/stellar-wallets-kit` library.
+This directory contains the wallet integration layer for the Stellar adapter, providing all wallet‑related UI, hooks, context, and utilities using `@creit.tech/stellar-wallets-kit`.
 
 ## Architectural Approach: Dual UI Support
 
 The Stellar adapter supports two UI modes:
 
-1. **Native UI Mode (`stellar-wallets-kit`)**: Uses the Stellar Wallets Kit's native button component, which provides a complete wallet management experience including:
-   - Wallet connection/selection modal
-   - Connected state with account address display
-   - Account management dialog with copy address and disconnect options
-
-2. **Custom UI Mode (`custom`)**: Uses custom React components for wallet UI, giving developers full control over the appearance and behavior of wallet interactions.
+1. Native UI Mode (`stellar-wallets-kit`): Uses the Stellar Wallets Kit’s native button and modal with address display and account management.
+2. Custom UI Mode (`custom`): Uses custom React components that match the Builder’s design system.
 
 ## Purpose
 
-- **UI Environment Provision**: Sets up the UI environment for Stellar wallet interactions. The adapter exports `StellarWalletUiRoot`, a React component that manages the wallet state and provides context to child components.
-- **Facade Hooks**: Exposes a standardized set of React hooks (`stellarFacadeHooks`) for wallet and account management, wrapping the Stellar Wallets Kit functionality.
-- **UI Components**: Provides custom-styled wallet UI components (`CustomConnectButton`, `CustomAccountDisplay`) that work with the Stellar ecosystem.
-- **Configuration**: Supports configuration through global application configuration (`AppConfigService`) and programmatic overrides.
+- UI Environment Provision: `StellarWalletUiRoot` provides a stable provider root for wallet state.
+- Facade Hooks: `stellarFacadeHooks` expose standardized hooks for connection and account status.
+- UI Components: Custom‑styled wallet components (`ConnectButton`, `AccountDisplay`).
+- Configuration: Layered config via `AppConfigService` and programmatic overrides.
 
 ## Directory Structure
 
-```bash
+```text
 wallet/
-├── components/         # Custom wallet UI components
+├── components/         # Wallet UI components & root
 │   ├── StellarWalletUiRoot.tsx
-│   ├── account/       # Account display component
-│   ├── connect/       # Connect button and dialog
-│   └── network/       # (Empty - Stellar doesn't support network switching)
-├── context/           # React context for wallet state
-│   ├── StellarWalletContext.ts
-│   └── useStellarWalletContext.ts
-├── hooks/             # Facade hooks and individual wallet hooks
-│   ├── facade-hooks.ts
-│   ├── useStellarAccount.ts
-│   ├── useStellarConnect.ts
-│   ├── useStellarDisconnect.ts
-│   └── useUiKitConfig.ts
-├── services/          # Configuration resolution service
-│   └── configResolutionService.ts
-├── stellar-wallets-kit/  # Stellar Wallets Kit integration
-│   ├── stellarUiKitManager.ts    # Manages UI kit state and configuration
-│   ├── StellarWalletsKitConnectButton.tsx  # ConnectButton component for Stellar Wallets Kit
-│   ├── config-generator.ts       # Generates config for exported apps
-│   └── export-service.ts         # Handles wallet config exports
-├── utils/             # Utilities for filtering components and UI kit service
-│   ├── filterWalletComponents.ts
-│   └── uiKitService.ts
-└── connection.ts      # Core wallet connection logic
+│   ├── account/
+│   ├── connect/
+│   └── network/        # (Not used: no network switching in Stellar)
+├── context/
+├── hooks/
+├── implementation/     # Stellar Wallets Kit implementation
+├── services/           # Wallet UI config resolution
+├── stellar-wallets-kit/
+├── utils/
+└── connection.ts
 ```
 
 ## Key Components & Concepts
 
-- **`StellarAdapter` UI Methods**:
-  - `getEcosystemReactUiContextProvider()`: Returns the `StellarWalletUiRoot` component.
-  - `configureUiKit(programmaticOverrides, options)`: Configures the UI kit and triggers the `stellarUiKitManager`.
-  - `getEcosystemWalletComponents()`: Returns UI components (ConnectButton, AccountDisplay) for the active kit.
-  - `getEcosystemReactHooks()`: Returns `stellarFacadeHooks`.
+- Adapter UI methods:
+  - `getEcosystemReactUiContextProvider()` → `StellarWalletUiRoot`
+  - `getEcosystemReactHooks()` → `stellarFacadeHooks`
+  - `getEcosystemWalletComponents()` → components for active kit
+- `stellarUiKitManager`: Singleton controller for kit state and network config
+- `StellarWalletUiRoot`: Stable provider that wires the kit and context
+- Facade hooks: `useStellarAccount`, `useStellarConnect`, `useStellarDisconnect`, `useUiKitConfig`
 
-- **`stellarUiKitManager`**: Singleton that manages the Stellar Wallets Kit instance, network configuration, and UI kit state.
+## Differences from EVM Wallet Module
 
-- **`StellarWalletUiRoot`**: The root provider component that:
-  - Manages wallet connection state
-  - Provides wallet context to child components
-  - Handles UI kit configuration
-  - Updates connection status periodically
-
-- **Facade Hooks**: Standardized hooks that wrap Stellar-specific functionality:
-  - `useStellarAccount`: Returns account connection status and address
-  - `useStellarConnect`: Provides wallet connection functionality with error handling and loading states
-  - `useStellarDisconnect`: Provides wallet disconnection functionality with error handling and loading states
-  - `useUiKitConfig`: Loads initial UI kit configuration from AppConfigService
-
-## Key Differences from EVM Adapter
-
-1. **No Network Switching**: Stellar doesn't support dynamic network switching after wallet connection, so there's no NetworkSwitcher component.
-
-2. **Different UI Kit Approach**: Supports both the Stellar Wallets Kit's built-in modal UI and custom components, but doesn't require the complex asset loading needed for libraries like RainbowKit.
-
-3. **Single Wallet Kit**: Uses `@creit.tech/stellar-wallets-kit` as the primary wallet integration library, rather than supporting multiple wallet libraries.
-
-4. **No Native Config Files**: Currently doesn't support loading TypeScript configuration files (though the infrastructure is in place if needed in the future).
+- No network switching component (Stellar wallets do not switch networks dynamically)
+- Single primary wallet kit (Stellar Wallets Kit) vs multiple kits on EVM
+- No native TypeScript config files are loaded for kit setup (can be added later)
 
 ## Configuration
 
-The Stellar adapter supports ecosystem-namespaced configuration through:
+1. Global App Config (`app.config.json`):
 
-1. **Global App Config** (`app.config.json`):
+   Ecosystem‑namespaced configuration under `globalServiceConfigs.walletui.stellar`.
 
-   Configuration is namespaced by ecosystem (e.g., `walletui.stellar`, `walletui.evm`) to support multi-ecosystem environments.
-
-   For custom UI components:
+   Custom UI components:
 
    ```json
    {
@@ -101,9 +66,7 @@ The Stellar adapter supports ecosystem-namespaced configuration through:
            "kitName": "custom",
            "kitConfig": {
              "showInjectedConnector": false,
-             "components": {
-               "exclude": ["NetworkSwitcher"]
-             }
+             "components": { "exclude": ["NetworkSwitcher"] }
            }
          }
        }
@@ -111,23 +74,20 @@ The Stellar adapter supports ecosystem-namespaced configuration through:
    }
    ```
 
-   For Stellar Wallets Kit native button (includes account management dialog):
+   Native kit button:
 
    ```json
    {
      "globalServiceConfigs": {
        "walletui": {
-         "stellar": {
-           "kitName": "stellar-wallets-kit",
-           "kitConfig": {}
-         }
+         "stellar": { "kitName": "stellar-wallets-kit", "kitConfig": {} }
        }
      }
    }
    ```
 
-2. **Programmatic Overrides**: Passed to `configureUiKit()` method
+2. Programmatic overrides: pass to `adapter.configureUiKit(overrides)`
 
-## Usage
+## Usage in Application
 
-The Stellar wallet module is automatically initialized when a Stellar network is selected in the application. The `StellarWalletUiRoot` component wraps the application content and provides wallet functionality through React context and hooks.
+`StellarWalletUiRoot` is returned by the adapter and used by the Builder’s `WalletStateProvider`. Use `useWalletState()` and facade hooks from `@openzeppelin/contracts-ui-builder-react-core` to render the wallet UI components from `getEcosystemWalletComponents()`.


### PR DESCRIPTION
Add Stellar adapter READMEs; expand main README Table of Contents and npm badges; move adapter-specific docs to package READMEs; mark adapter statuses and clean sections.

- Stellar adapter: main, networks, wallet READMEs
- Main README: ToC, badges for all published packages, adapter statuses, remove deep adapter sections
- EVM wallet README: lint fixes

No functional code changes.